### PR TITLE
Make QueuePairEndpoint serializable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ travis-ci = { repository = "jonhoo/rust-ibverbs" }
 
 [build-dependencies]
 bindgen = "0.36"
+
+[dependencies]
+serde = "1.0"
+serde_derive = "1.0"
+# serde_json = "1.0"


### PR DESCRIPTION
ibverbs requires another inter-process communication to exchange their endpoint for connection establishment. As QueuePairEndpoint includes private ffi pointer it is hard to serialize outside the rust-ibverbs module and it would be more natural to use standardized way of serde in Rust.