### PR TITLE
Submodule initialization added to build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,12 @@ fn main() {
     println!("cargo:rustc-link-search=native=vendor/rdma-core/build/lib");
     println!("cargo:rustc-link-lib=ibverbs");
 
+    // initialize and update submodules
+    Command::new("git")
+        .args(&["submodule", "update", "--init"])
+        .status()
+        .expect("Failed to update submodules.");
+
     // build vendor/rdma-core
     Command::new("bash")
         .current_dir("vendor/rdma-core/")


### PR DESCRIPTION
_Cargo_ do not initialize submodules by itself and this functionality is not in the _build.rs_ file. This would cause build to fail if the crate was downloaded from _crates.io_ by cargo. Little change to _build.rs_ initializes submodules.