### PR TITLE
Implement ser/der for QueuePairEndpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,16 @@ exclude = ["vendor/rdma-core/build/"]
 travis-ci = { repository = "jonhoo/rust-ibverbs" }
 maintenance = { status = "looking-for-maintainer" }
 
+[dependencies.serde]
+version = "1.0"
+optional = true
+features = ["derive"]
+
 [build-dependencies]
 bindgen = "0.36"
+
+[features]
+default = ["serde"]
+
+[dev-dependencies]
+bincode = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ibverbs"
 version = "0.4.4"
+edition = "2018"
 
 description = "Bindings for RDMA ibverbs through rdma-core"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@ impl Context {
 
         // let mut gid = ffi::ibv_gid::default();
         let mut gid = Gid::default();
-        let ok = unsafe { ffi::ibv_query_gid(ctx, PORT_NUM, 0, gid.as_mut() as _) };
+        let ok = unsafe { ffi::ibv_query_gid(ctx, PORT_NUM, 0, gid.as_mut()) };
         if ok != 0 {
             return Err(io::Error::last_os_error());
         }
@@ -831,19 +831,13 @@ impl From<Gid> for ffi::ibv_gid {
 
 impl AsRef<ffi::ibv_gid> for Gid {
     fn as_ref(&self) -> &ffi::ibv_gid {
-        unsafe { self.raw.as_ptr().cast::<ffi::ibv_gid>().as_ref().unwrap() }
+        unsafe { &*self.raw.as_ptr().cast::<ffi::ibv_gid>() }
     }
 }
 
 impl AsMut<ffi::ibv_gid> for Gid {
     fn as_mut(&mut self) -> &mut ffi::ibv_gid {
-        unsafe {
-            self.raw
-                .as_mut_ptr()
-                .cast::<ffi::ibv_gid>()
-                .as_mut()
-                .unwrap()
-        }
+        unsafe { &mut *self.raw.as_mut_ptr().cast::<ffi::ibv_gid>() }
     }
 }
 


### PR DESCRIPTION
Make `QueuePairEndpoint` serializable. 

I use the same essential strategy (and some of the code) as @kuenishi. The reason we can't just slap a `#[derive(Serialize, Deserialize)]` is that `QueuePairEndpoint` contains a `C` style `union`, which `serde` does not want to mess with. I get around this by providing idiomatic conversions from/to `PortableQPEndpoint`, and telling serde to use `PortableQPEndpoint` as an intermediary for serialization and deserialization. 

For a larger struct, you could implement custom serializers and deserializers, but this copy strategy works well for small structs. 

I also implement `fmt::Debug` and `PartialEq` for `QueuePairEndpoint`.  