### PR TITLE
Fix version mistake in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibverbs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 
 description = "Bindings for RDMA ibverbs through rdma-core"


### PR DESCRIPTION
The version number was bumped to 0.6 in version control with the last commit.  It seems that we did not reflect this change in the Cargo.toml file as well.