### PR TITLE
Bump bindgen version to 0.62

### DIFF
--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -28,4 +28,4 @@ travis-ci = { repository = "jonhoo/rust-ibverbs" }
 maintenance = { status = "looking-for-maintainer" }
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = "0.62"


### PR DESCRIPTION
Hello,

When building the `ibverbs-sys` crate as a dependency on Arch Linux with clang-16, I encountered failures. The error is quite similar to the original one in #21 at a glance:

```
  In file included from /home/chen/.cargo/registry/src/github.com-1ecc6299db9ec823/ibverbs-sys-0.1.0/vendor/rdma-core/build/include/ccan/minmax.h:7,
                   from /home/chen/.cargo/registry/src/github.com-1ecc6299db9ec823/ibverbs-sys-0.1.0/vendor/rdma-core/librdmacm/cma.h:48,
                   from /home/chen/.cargo/registry/src/github.com-1ecc6299db9ec823/ibverbs-sys-0.1.0/vendor/rdma-core/librdmacm/acm.c:43:
  /home/chen/.cargo/registry/src/github.com-1ecc6299db9ec823/ibverbs-sys-0.1.0/vendor/rdma-core/librdmacm/acm.c: In function ‘ucma_ib_init’:
  /home/chen/.cargo/registry/src/github.com-1ecc6299db9ec823/ibverbs-sys-0.1.0/vendor/rdma-core/build/include/ccan/build_assert.h:23:33: error: size of unnamed array is negative
     23 |         do { (void) sizeof(char [1 - 2*!(cond)]); } while(0)
        |                                 ^
  /home/chen/.cargo/registry/src/github.com-1ecc6299db9ec823/ibverbs-sys-0.1.0/vendor/rdma-core/librdmacm/acm.c:105:17: note: in expansion of macro ‘BUILD_ASSERT’
    105 |                 BUILD_ASSERT(sizeof(IBACM_SERVER_PATH) <=
        |                 ^~~~~~~~~~~~
```

The `IBACM_SERVER_PATH` was indeed too long but it seems not to be the root cause because it's an expansion of a `~/.cargo` path. It is long, but on another Ubuntu server with the same username, I successfully compiled it.

I noticed that the real complaint is:

```
thread 'main' panicked at '"__atomic_wide_counter_struct_(unnamed_at_/usr/include/bits/atomic_wide_counter_h_28_3)" is not a valid Ident', /home/chen/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.66/src/fallback.rs:774:9
```

Some search brings me to a relatively new post:

https://stackoverflow.com/questions/76443280/rust-bindgen-causes-a-is-not-a-valid-ident-error-on-build
https://github.com/rust-lang/rust-bindgen/issues/2312

And upgrading the version of `bindgen` solved my compilation issue. It might be a good idea to upgrade it to a newer version (0.62 works, as suggested in the SO post).

Thank you!