### PR TITLE
Make the Endpoint fields accessible and the Gid optional

### DIFF
--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -860,7 +860,7 @@ pub struct PreparedQueuePair<'res> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-struct Gid {
+pub struct Gid {
     raw: [u8; 16],
 }
 
@@ -914,9 +914,12 @@ impl AsMut<ffi::ibv_gid> for Gid {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct QueuePairEndpoint {
-    num: u32,
-    lid: u16,
-    gid: Gid,
+    /// the `QueuePair`'s `qp_num`
+    pub num: u32,
+    /// the context's `lid`
+    pub lid: u16,
+    /// the context's `gid`, used for global routing
+    pub gid: Gid,
 }
 
 impl<'res> PreparedQueuePair<'res> {


### PR DESCRIPTION
I do have an existing C application I want to communicate with and I think it's not using global routing, so I have to get the (lid, qpn) information out of this library and into the other application (and back).

Because `QueuePairEndpoint` is already `Serialize` and `Deserialize`, I don't think that making the fields public has any serious implications (though adding getter functions and a `new` function might be nicer, idk).