### PR TITLE
 Set attributes only on queue pairs of the correct type 

### DIFF
--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -556,6 +556,7 @@ pub struct QueuePairBuilder<'res> {
     min_rnr_timer: u8,
     max_rd_atomic: u8,
     max_dest_rd_atomic: u8,
+    path_mtu: u32,
 }
 
 impl<'res> QueuePairBuilder<'res> {
@@ -606,6 +607,7 @@ impl<'res> QueuePairBuilder<'res> {
             timeout: 4,
             max_rd_atomic: 1,
             max_dest_rd_atomic: 1,
+            path_mtu: pd.ctx.port_attr.active_mtu,
         }
     }
 
@@ -766,6 +768,21 @@ impl<'res> QueuePairBuilder<'res> {
         self
     }
 
+    /// Set the path MTU.
+    ///
+    /// Defaults to the port's active_mtu.
+    /// The possible values are:
+    ///  - 1: 256
+    ///  - 2: 512
+    ///  - 3: 1024
+    ///  - 4: 2048
+    ///  - 5: 4096
+    pub fn set_path_mtu(&mut self, path_mtu: u32) -> &mut Self {
+        assert!((1..=5).contains(&path_mtu));
+        self.path_mtu = path_mtu;
+        self
+    }
+
     /// Set the opaque context value for the new `QueuePair`.
     ///
     /// Defaults to 0.
@@ -822,6 +839,7 @@ impl<'res> QueuePairBuilder<'res> {
                 min_rnr_timer: self.min_rnr_timer,
                 max_rd_atomic: self.max_rd_atomic,
                 max_dest_rd_atomic: self.max_dest_rd_atomic,
+                path_mtu: self.path_mtu,
             })
         }
     }
@@ -863,6 +881,7 @@ pub struct PreparedQueuePair<'res> {
     rnr_retry: u8,
     max_rd_atomic: u8,
     max_dest_rd_atomic: u8,
+    path_mtu: u32,
 }
 
 /// A Global identifier for ibv.
@@ -1016,7 +1035,7 @@ impl<'res> PreparedQueuePair<'res> {
         // set ready to receive
         let mut attr = ffi::ibv_qp_attr {
             qp_state: ffi::ibv_qp_state::IBV_QPS_RTR,
-            path_mtu: self.ctx.port_attr.active_mtu,
+            path_mtu: self.path_mtu,
             dest_qp_num: remote.num,
             rq_psn: 0,
             max_dest_rd_atomic: self.max_dest_rd_atomic,

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -554,6 +554,7 @@ pub struct QueuePairBuilder<'res> {
     retry_count: u8,
     rnr_retry: u8,
     min_rnr_timer: u8,
+    max_rd_atomic: u8,
     max_dest_rd_atomic: u8,
 }
 
@@ -603,6 +604,7 @@ impl<'res> QueuePairBuilder<'res> {
             retry_count: 6,
             rnr_retry: 6,
             timeout: 4,
+            max_rd_atomic: 1,
             max_dest_rd_atomic: 1,
         }
     }
@@ -748,6 +750,14 @@ impl<'res> QueuePairBuilder<'res> {
         self
     }
 
+    /// Set the number of outstanding RDMA reads & atomic operations on the destination Queue Pair.
+    ///
+    /// This defaults to 1.
+    pub fn set_max_rd_atomic(&mut self, max_rd_atomic: u8) -> &mut Self {
+        self.max_rd_atomic = max_rd_atomic;
+        self
+    }
+
     /// Set the number of responder resources for handling incoming RDMA reads & atomic operations.
     ///
     /// This defaults to 1.
@@ -810,6 +820,7 @@ impl<'res> QueuePairBuilder<'res> {
                 retry_count: self.retry_count,
                 rnr_retry: self.rnr_retry,
                 min_rnr_timer: self.min_rnr_timer,
+                max_rd_atomic: self.max_rd_atomic,
                 max_dest_rd_atomic: self.max_dest_rd_atomic,
             })
         }
@@ -850,6 +861,7 @@ pub struct PreparedQueuePair<'res> {
     timeout: u8,
     retry_count: u8,
     rnr_retry: u8,
+    max_rd_atomic: u8,
     max_dest_rd_atomic: u8,
 }
 
@@ -973,8 +985,6 @@ impl<'res> PreparedQueuePair<'res> {
     /// rq_psn = 0;
     /// sq_psn = 0;
     ///
-    /// max_rd_atomic = 1;
-    ///
     /// ah_attr.sl = 0;
     /// ah_attr.src_path_bits = 0;
     /// ```
@@ -1045,7 +1055,7 @@ impl<'res> PreparedQueuePair<'res> {
             retry_cnt: self.retry_count,
             sq_psn: 0,
             rnr_retry: self.rnr_retry,
-            max_rd_atomic: 1,
+            max_rd_atomic: self.max_rd_atomic,
             ..Default::default()
         };
         let mask = ffi::ibv_qp_attr_mask::IBV_QP_STATE

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -557,6 +557,7 @@ pub struct QueuePairBuilder<'res> {
     max_rd_atomic: u8,
     max_dest_rd_atomic: u8,
     path_mtu: u32,
+    rq_psn: u32,
 }
 
 impl<'res> QueuePairBuilder<'res> {
@@ -608,6 +609,7 @@ impl<'res> QueuePairBuilder<'res> {
             max_rd_atomic: 1,
             max_dest_rd_atomic: 1,
             path_mtu: pd.ctx.port_attr.active_mtu,
+            rq_psn: 0,
         }
     }
 
@@ -783,6 +785,14 @@ impl<'res> QueuePairBuilder<'res> {
         self
     }
 
+    /// Set the PSN for the receive queue.
+    ///
+    /// Defaults to 0.
+    pub fn set_rq_psn(&mut self, rq_psn: u32) -> &mut Self {
+        self.rq_psn = rq_psn;
+        self
+    }
+
     /// Set the opaque context value for the new `QueuePair`.
     ///
     /// Defaults to 0.
@@ -840,6 +850,7 @@ impl<'res> QueuePairBuilder<'res> {
                 max_rd_atomic: self.max_rd_atomic,
                 max_dest_rd_atomic: self.max_dest_rd_atomic,
                 path_mtu: self.path_mtu,
+                rq_psn: self.rq_psn,
             })
         }
     }
@@ -882,6 +893,7 @@ pub struct PreparedQueuePair<'res> {
     max_rd_atomic: u8,
     max_dest_rd_atomic: u8,
     path_mtu: u32,
+    rq_psn: u32,
 }
 
 /// A Global identifier for ibv.
@@ -1001,7 +1013,6 @@ impl<'res> PreparedQueuePair<'res> {
     /// ```text,ignore
     /// port_num = PORT_NUM;
     /// pkey_index = 0;
-    /// rq_psn = 0;
     /// sq_psn = 0;
     ///
     /// ah_attr.sl = 0;
@@ -1037,7 +1048,7 @@ impl<'res> PreparedQueuePair<'res> {
             qp_state: ffi::ibv_qp_state::IBV_QPS_RTR,
             path_mtu: self.path_mtu,
             dest_qp_num: remote.num,
-            rq_psn: 0,
+            rq_psn: self.rq_psn,
             max_dest_rd_atomic: self.max_dest_rd_atomic,
             min_rnr_timer: self.min_rnr_timer,
             ah_attr: ffi::ibv_ah_attr {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -650,7 +650,7 @@ impl<'res> QueuePairBuilder<'res> {
             || self.qp_type == ffi::ibv_qp_type::IBV_QPT_UC
         {
             self.access = Some(
-                self.access.unwrap()
+                self.access.expect("always set to Some in new")
                     | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE
                     | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_READ,
             );
@@ -807,6 +807,7 @@ impl<'res> QueuePairBuilder<'res> {
     /// Set the number of responder resources for handling incoming RDMA reads & atomic operations.
     ///
     /// This defaults to 1.
+    /// Valid only for RC QPs.
     pub fn set_max_dest_rd_atomic(&mut self, max_dest_rd_atomic: u8) -> &mut Self {
         if self.qp_type == ffi::ibv_qp_type::IBV_QPT_RC {
             self.max_dest_rd_atomic = Some(max_dest_rd_atomic);
@@ -817,6 +818,7 @@ impl<'res> QueuePairBuilder<'res> {
     /// Set the path MTU.
     ///
     /// Defaults to the port's active_mtu.
+    /// Valid only for RC and UC QPs.
     /// The possible values are:
     ///  - 1: 256
     ///  - 2: 512
@@ -836,6 +838,7 @@ impl<'res> QueuePairBuilder<'res> {
     /// Set the PSN for the receive queue.
     ///
     /// Defaults to 0.
+    /// Valid only for RC and UC QPs.
     pub fn set_rq_psn(&mut self, rq_psn: u32) -> &mut Self {
         if self.qp_type == ffi::ibv_qp_type::IBV_QPT_RC
             || self.qp_type == ffi::ibv_qp_type::IBV_QPT_UC

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -554,6 +554,7 @@ pub struct QueuePairBuilder<'res> {
     retry_count: u8,
     rnr_retry: u8,
     min_rnr_timer: u8,
+    max_dest_rd_atomic: u8,
 }
 
 impl<'res> QueuePairBuilder<'res> {
@@ -602,6 +603,7 @@ impl<'res> QueuePairBuilder<'res> {
             retry_count: 6,
             rnr_retry: 6,
             timeout: 4,
+            max_dest_rd_atomic: 1,
         }
     }
 
@@ -746,6 +748,14 @@ impl<'res> QueuePairBuilder<'res> {
         self
     }
 
+    /// Set the number of responder resources for handling incoming RDMA reads & atomic operations.
+    ///
+    /// This defaults to 1.
+    pub fn set_max_dest_rd_atomic(&mut self, max_dest_rd_atomic: u8) -> &mut Self {
+        self.max_dest_rd_atomic = max_dest_rd_atomic;
+        self
+    }
+
     /// Set the opaque context value for the new `QueuePair`.
     ///
     /// Defaults to 0.
@@ -800,6 +810,7 @@ impl<'res> QueuePairBuilder<'res> {
                 retry_count: self.retry_count,
                 rnr_retry: self.rnr_retry,
                 min_rnr_timer: self.min_rnr_timer,
+                max_dest_rd_atomic: self.max_dest_rd_atomic,
             })
         }
     }
@@ -839,6 +850,7 @@ pub struct PreparedQueuePair<'res> {
     timeout: u8,
     retry_count: u8,
     rnr_retry: u8,
+    max_dest_rd_atomic: u8,
 }
 
 /// A Global identifier for ibv.
@@ -961,7 +973,6 @@ impl<'res> PreparedQueuePair<'res> {
     /// rq_psn = 0;
     /// sq_psn = 0;
     ///
-    /// max_dest_rd_atomic = 1;
     /// max_rd_atomic = 1;
     ///
     /// ah_attr.sl = 0;
@@ -998,7 +1009,7 @@ impl<'res> PreparedQueuePair<'res> {
             path_mtu: self.ctx.port_attr.active_mtu,
             dest_qp_num: remote.num,
             rq_psn: 0,
-            max_dest_rd_atomic: 1,
+            max_dest_rd_atomic: self.max_dest_rd_atomic,
             min_rnr_timer: self.min_rnr_timer,
             ah_attr: ffi::ibv_ah_attr {
                 dlid: remote.lid,


### PR DESCRIPTION
Some of the Queue Pair attributes are only valid for connections and some are only valid for reliable connections.
Setting an attribute that is not valid, might produce `EINVAL` (at least, it did for me. I'm not sure from the man pages whether this always happens).

So, what I've done is add setters for those fields that did not already have one and then, convert those fields to `Option`s and add `panic`s to those setters.

I'm not quite satisfied with panicking and I already thought about replacing the fields (and the type field) with two optional structs named `Connection` and `Reliability` (?), but then I don't know how to set them. Plus, the approach I took is compatible with existing code.

I only modified the fields on `PreparedQueuePair` and `QueuePairBuilder`. This is enough to get a UC QP up and running, for UD, the `Endpoint` struct would probably need to change.