### PR TITLE
Expose IBV_LINK_LAYER_.* constants

### DIFF
--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -41,6 +41,7 @@ fn main() {
         .clang_arg(format!("-I{built_in}/include/"))
         .allowlist_function("ibv_.*")
         .allowlist_type("ibv_.*")
+        .allowlist_var("IBV_LINK_LAYER_.*")
         .bitfield_enum("ibv_access_flags")
         .bitfield_enum("ibv_qp_attr_mask")
         .bitfield_enum("ibv_wc_flags")


### PR DESCRIPTION
These are useful for matching against and providing some known constant numeric values with meaningful names.

Fixes #40.