### PR TITLE
Upgrade rdma-core + bindgen

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -105,7 +105,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.70.0"] # bindgen 1.69
+        msrv: ["1.82.0"] # bindgen 1.71
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,16 +22,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -40,7 +38,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -51,9 +48,12 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cexpr"
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
 ]
@@ -97,33 +97,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "errno"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "ibverbs"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "ibverbs-sys",
@@ -132,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ibverbs-sys"
-version = "0.2.1+52.0"
+version = "0.3.0+55.0"
 dependencies = [
  "bindgen",
  "cmake",
@@ -141,46 +122,28 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -211,16 +174,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -228,27 +185,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -258,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -269,43 +226,30 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.38.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -320,9 +264,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "70ae51629bf965c5c098cc9e87908a3df5301051a9e087d6f9bef5c9771ed126"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -331,30 +275,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,6 @@ dependencies = [
  "bindgen",
  "cmake",
  "proc-macro2",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ version = "0.3.0+55.0"
 dependencies = [
  "bindgen",
  "cmake",
+ "proc-macro2",
  "regex",
 ]
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Completion Queues, Queue-Pairs, Shared Receive Queues, Address Handles, and Memo
 also handles sending and receiving data posted to QPs and SRQs, and getting completions from
 CQs using polling and completions events.
 
-A good place to start is to look at the programs in [`examples/`](ibverbs/examples/), and the upstream
-[C examples]. You can test RDMA programs on modern Linux kernels even without specialized RDMA
-hardware by using [SoftRoCE][soft].
+A good place to start is to look at the programs in [`examples/`](ibverbs/examples/), and the
+upstream [C examples]. You can test RDMA programs on modern Linux kernels even without specialized
+RDMA hardware by using [SoftRoCE][soft].
 
 ## For the detail-oriented
 

--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -29,4 +29,5 @@ cmake = "0.1.50"
 
 # to make -Zminimal-versions work
 [target.'cfg(any())'.dependencies]
+# https://github.com/rust-lang/rust-bindgen/pull/3048
 proc-macro2 = { version = "1.0.80", optional = true }

--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -29,5 +29,4 @@ cmake = "0.1.50"
 
 # to make -Zminimal-versions work
 [target.'cfg(any())'.dependencies]
-regex = { version = "1.6", optional = true }
 proc-macro2 = { version = "1.0.80", optional = true }

--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibverbs-sys"
-version = "0.2.1+52.0"
+version = "0.3.0+55.0"
 edition = "2021"
 
 description = "Raw, FFI bindings for RDMA ibverbs through rdma-core"
@@ -23,7 +23,7 @@ license = "MIT OR Apache-2.0"
 exclude = ["vendor/rdma-core/build/"]
 
 [build-dependencies]
-bindgen = "0.69.2"
+bindgen = "0.71.1"
 cmake = "0.1.50"
 
 # to make -Zminimal-versions work

--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ibverbs-sys"
 version = "0.3.0+55.0"
 edition = "2021"
+rust-version = "1.82" # unsafe extern in generated bindings
 
 description = "Raw, FFI bindings for RDMA ibverbs through rdma-core"
 readme = "../README.md"

--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -29,4 +29,5 @@ cmake = "0.1.50"
 
 # to make -Zminimal-versions work
 [target.'cfg(any())'.dependencies]
-regex = "1.6"
+regex = { version = "1.6", optional = true }
+proc-macro2 = { version = "1.0.80", optional = true }

--- a/ibverbs/Cargo.toml
+++ b/ibverbs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibverbs"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 
 description = "Bindings for RDMA ibverbs through rdma-core"
@@ -19,7 +19,7 @@ categories = ["network-programming", "api-bindings"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-ffi = { path = "../ibverbs-sys", package = "ibverbs-sys", version = "0.2.0" }
+ffi = { path = "../ibverbs-sys", package = "ibverbs-sys", version = "0.3.0" }
 
 [dependencies.serde]
 version = "1.0.100"


### PR DESCRIPTION
ibverbs-sys 0.3.0+55.0: 55.0 + bindgen + pub consts + non-in-place build
ibverbs 0.9.0: -sys 0.3.0 + configurable work queue limits

rdma-core bump is for https://github.com/linux-rdma/rdma-core/pull/1485
bindgen bump is for https://github.com/harryfei/which-rs/issues/104

Includes #38, #39, #41, and #42.