### PR TITLE
Allow building under longer paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "ibverbs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bincode",
  "ibverbs-sys",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ibverbs-sys"
-version = "0.3.0+55.0"
+version = "0.3.1+55.0"
 dependencies = [
  "bindgen",
  "cmake",

--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibverbs-sys"
-version = "0.3.0+55.0"
+version = "0.3.1+55.0"
 edition = "2021"
 rust-version = "1.82" # unsafe extern in generated bindings
 

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -28,6 +28,18 @@ fn main() {
     eprintln!("run cmake");
     let built_in = cmake::Config::new("vendor/rdma-core")
         .define("NO_MAN_PAGES", "1")
+        // cmake crate defaults CMAKE_INSTALL_PREFIX to the output directory
+        //
+        //   https://github.com/rust-lang/cmake-rs/blob/94da9de2ea79ab6cad572e908864a160cf4847a9/src/lib.rs#L699-L703
+        //
+        // this results in overly long runtime paths on docs.rs, which then fail the build. it also
+        // causes sadness for users trying to build since the bindings may fail to build for the
+        // same reason (see https://github.com/jonhoo/rust-ibverbs/pull/41 for what was an
+        // incomplete fix).
+        //
+        // since we never actually _install_ anything when building here, we should be able to
+        // safely set this to any short path. simply by convention we set it to `/usr`.
+        .define("CMAKE_INSTALL_PREFIX", "/usr")
         .no_build_target(true)
         .build();
     let built_in = built_in

--- a/ibverbs/Cargo.toml
+++ b/ibverbs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibverbs"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 
 description = "Bindings for RDMA ibverbs through rdma-core"


### PR DESCRIPTION
It turns out that #41 was insufficient since `cmake` will forcibly _set_ `CMAKE_INSTALL_PREFIX` to the output directory (which is under the target directory) if it isn't already set[1]. So, we need to explicitly set a short dummy value.

This should hopefully _actually_ fix docs.rs builds.

The version bump to ibverbs (non-sys) is just to force docs.rs to attempt re-generation of the docs.

[1]: https://github.com/rust-lang/cmake-rs/blob/94da9de2ea79ab6cad572e908864a160cf4847a9/src/lib.rs#L699-L703