### PR TITLE
Expose context gid table and allow setting qp gid

### DIFF
--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -56,6 +56,7 @@ fn main() {
         .header("vendor/rdma-core/libibverbs/verbs.h")
         .clang_arg(format!("-I{built_in}/include/"))
         .allowlist_function("ibv_.*")
+        .allowlist_function("_ibv_.*")
         .allowlist_type("ibv_.*")
         .allowlist_var("IBV_LINK_LAYER_.*")
         .bitfield_enum("ibv_access_flags")
@@ -77,7 +78,6 @@ fn main() {
         .derive_debug(true)
         .prepend_enum_name(false)
         .blocklist_type("ibv_wc")
-        .wrap_static_fns(true)
         .size_t_is_usize(true)
         .generate()
         .expect("Unable to generate bindings");

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -73,6 +73,7 @@ fn main() {
         .derive_debug(true)
         .prepend_enum_name(false)
         .blocklist_type("ibv_wc")
+        .wrap_static_fns(true)
         .size_t_is_usize(true)
         .generate()
         .expect("Unable to generate bindings");

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("failed to get current directory");
     println!("cargo:include={manifest_dir}/vendor/rdma-core/build/include");
+    println!("cargo:rustc-link-search=native={manifest_dir}/vendor/rdma-core/build/lib");
     println!("cargo:rustc-link-lib=ibverbs");
 
     if Path::new("vendor/rdma-core/CMakeLists.txt").exists() {

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -51,6 +51,7 @@ fn main() {
     let bindings = bindgen::Builder::default()
         .header("vendor/rdma-core/libibverbs/verbs.h")
         .clang_arg(format!("-I{built_in}/include/"))
+        .allowlist_function("_ibv_.*")
         .allowlist_function("ibv_.*")
         .allowlist_type("ibv_.*")
         .allowlist_var("IBV_LINK_LAYER_.*")
@@ -73,7 +74,6 @@ fn main() {
         .derive_debug(true)
         .prepend_enum_name(false)
         .blocklist_type("ibv_wc")
-        .wrap_static_fns(true)
         .size_t_is_usize(true)
         .generate()
         .expect("Unable to generate bindings");

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -4,12 +4,7 @@ use std::process::Command;
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("failed to get current directory");
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     println!("cargo:include={manifest_dir}/vendor/rdma-core/build/include");
-    println!(
-        "cargo:rustc-link-search=native={manifest_dir}/vendor/rdma-core/build/lib;{}",
-        out_path.to_str().unwrap()
-    );
     println!("cargo:rustc-link-lib=ibverbs");
 
     if Path::new("vendor/rdma-core/CMakeLists.txt").exists() {
@@ -83,6 +78,7 @@ fn main() {
         .expect("Unable to generate bindings");
 
     // write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Could not write bindings");

--- a/ibverbs/examples/loopback.rs
+++ b/ibverbs/examples/loopback.rs
@@ -12,6 +12,7 @@ fn main() {
 
     let qp_builder = pd
         .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_RC)
+        .set_gid_index(1)
         .build()
         .unwrap();
 

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -378,9 +378,16 @@ impl Context {
         }
 
         let mut gid_table = vec![ffi::ibv_gid_entry::default(); port_attr.gid_tbl_len as usize];
-        let num_entries =
-            unsafe { ffi::ibv_query_gid_table(ctx, gid_table.as_mut_ptr(), gid_table.len(), 0) };
-        assert_eq!(num_entries as usize, gid_table.len());
+        let num_entries = unsafe {
+            ffi::_ibv_query_gid_table(
+                ctx,
+                gid_table.as_mut_ptr(),
+                gid_table.len(),
+                0,
+                size_of::<ffi::ibv_gid_entry>(),
+            )
+        };
+        gid_table.truncate(num_entries as usize);
         let gid_table = gid_table.into_iter().map(GidEntry::from).collect();
 
         Ok(Context {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -387,6 +387,12 @@ impl Context {
                 size_of::<ffi::ibv_gid_entry>(),
             )
         };
+        if num_entries < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("failed to query gid table, error={}", -num_entries),
+            ));
+        }
         gid_table.truncate(num_entries as usize);
         let gid_table = gid_table.into_iter().map(GidEntry::from).collect();
 

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -377,18 +377,18 @@ impl Context {
             }
         }
 
-        let mut gid_table = vec![ffi::ibv_gid_entry::default(); port_attr.gid_tbl_len as usize];
+        let mut raw_gid_tbl = vec![ffi::ibv_gid_entry::default(); port_attr.gid_tbl_len as usize];
         let num_entries = unsafe {
             ffi::_ibv_query_gid_table(
                 ctx,
-                gid_table.as_mut_ptr(),
-                gid_table.len(),
+                raw_gid_tbl.as_mut_ptr(),
+                raw_gid_tbl.len(),
                 0,
                 size_of::<ffi::ibv_gid_entry>(),
             )
         };
-        assert_eq!(num_entries as usize, gid_table.len());
-        let gid_table = gid_table.into_iter().map(GidEntry::from).collect();
+        assert_eq!(num_entries as usize, raw_gid_tbl.len());
+        let gid_table = raw_gid_tbl.into_iter().map(GidEntry::from).collect();
 
         Ok(Context {
             ctx,

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1086,6 +1086,7 @@ pub struct GidEntry {
     /// enum ibv_gid_type, can be one of IBV_GID_TYPE_IB, IBV_GID_TYPE_ROCE_V1 or IBV_GID_TYPE_ROCE_V2.
     pub gid_type: ffi::ibv_gid_type,
     /// The interface index of the net device associated with this GID.
+    ///
     /// It is 0 if there is no net device associated with it.
     pub ndev_ifindex: u32,
 }

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1038,16 +1038,14 @@ impl Gid {
     /// Expose the subnet_prefix component of the `Gid` as a u64. This is
     /// equivalent to accessing the `global.subnet_prefix` component of the
     /// `ffi::ibv_gid` union.
-    #[allow(dead_code)]
-    fn subnet_prefix(&self) -> u64 {
+    pub fn subnet_prefix(&self) -> u64 {
         u64::from_be_bytes(self.raw[..8].try_into().unwrap())
     }
 
     /// Expose the interface_id component of the `Gid` as a u64. This is
     /// equivalent to accessing the `global.interface_id` component of the
     /// `ffi::ibv_gid` union.
-    #[allow(dead_code)]
-    fn interface_id(&self) -> u64 {
+    pub fn interface_id(&self) -> u64 {
         u64::from_be_bytes(self.raw[8..].try_into().unwrap())
     }
 }

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -379,7 +379,7 @@ impl Context {
 
         // let mut gid = ffi::ibv_gid::default();
         let mut gid = Gid::default();
-        let ok = unsafe { ffi::ibv_query_gid(ctx, PORT_NUM, 0, gid.as_mut()) };
+        let ok = unsafe { ffi::ibv_query_gid(ctx, PORT_NUM, 3, gid.as_mut()) };
         if ok != 0 {
             return Err(io::Error::last_os_error());
         }

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -378,8 +378,15 @@ impl Context {
         }
 
         let mut gid_table = vec![ffi::ibv_gid_entry::default(); port_attr.gid_tbl_len as usize];
-        let num_entries =
-            unsafe { ffi::ibv_query_gid_table(ctx, gid_table.as_mut_ptr(), gid_table.len(), 0) };
+        let num_entries = unsafe {
+            ffi::_ibv_query_gid_table(
+                ctx,
+                gid_table.as_mut_ptr(),
+                gid_table.len(),
+                0,
+                size_of::<ffi::ibv_gid_entry>(),
+            )
+        };
         assert_eq!(num_entries as usize, gid_table.len());
         let gid_table = gid_table.into_iter().map(GidEntry::from).collect();
 

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1145,6 +1145,9 @@ impl<'res> PreparedQueuePair<'res> {
             attr.ah_attr.is_global = 1;
             attr.ah_attr.grh.dgid = gid.into();
             attr.ah_attr.grh.hop_limit = 0xff;
+            attr.ah_attr.grh.sgid_index = 3;
+        } else {
+            panic!();
         }
         let mut mask = ffi::ibv_qp_attr_mask::IBV_QP_STATE
             | ffi::ibv_qp_attr_mask::IBV_QP_AV

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -377,18 +377,11 @@ impl Context {
             }
         }
 
-        let mut raw_gid_tbl = vec![ffi::ibv_gid_entry::default(); port_attr.gid_tbl_len as usize];
-        let num_entries = unsafe {
-            ffi::_ibv_query_gid_table(
-                ctx,
-                raw_gid_tbl.as_mut_ptr(),
-                raw_gid_tbl.len(),
-                0,
-                size_of::<ffi::ibv_gid_entry>(),
-            )
-        };
-        assert_eq!(num_entries as usize, raw_gid_tbl.len());
-        let gid_table = raw_gid_tbl.into_iter().map(GidEntry::from).collect();
+        let mut gid_table = vec![ffi::ibv_gid_entry::default(); port_attr.gid_tbl_len as usize];
+        let num_entries =
+            unsafe { ffi::ibv_query_gid_table(ctx, gid_table.as_mut_ptr(), gid_table.len(), 0) };
+        assert_eq!(num_entries as usize, gid_table.len());
+        let gid_table = gid_table.into_iter().map(GidEntry::from).collect();
 
         Ok(Context {
             ctx,

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1201,8 +1201,6 @@ impl<'res> PreparedQueuePair<'res> {
             attr.ah_attr.grh.dgid = gid.into();
             attr.ah_attr.grh.hop_limit = 0xff;
             attr.ah_attr.grh.sgid_index = self.gid_index as u8;
-        } else {
-            panic!();
         }
         let mut mask = ffi::ibv_qp_attr_mask::IBV_QP_STATE
             | ffi::ibv_qp_attr_mask::IBV_QP_AV

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -677,6 +677,7 @@ impl<'res> QueuePairBuilder<'res> {
     ///
     /// Defaults to 0.
     pub fn set_gid_index(&mut self, gid_index: usize) -> &mut Self {
+        assert!(gid_index < self.pd.ctx.gid_table.len());
         self.gid_index = gid_index;
         self
     }

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1082,6 +1082,7 @@ impl AsMut<ffi::ibv_gid> for Gid {
 ///
 /// This struct acts as a rust wrapper for `ffi::ibv_gid_entry`. We use it instead of
 /// `ffi::ibv_gid_entry` because `ffi::ibv_gid` is wrapped by `Gid`.
+#[derive(Debug, Clone)]
 pub struct GidEntry {
     /// The GID entry.
     pub gid: Gid,


### PR DESCRIPTION
Before this change, gid defaulted to 0. On many devices there are multiple gids and 0 might not be the correct one.