### PR TITLE
cq wait using fd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ version = "0.9.2"
 dependencies = [
  "bincode",
  "ibverbs-sys",
+ "libc",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,7 +114,7 @@ version = "0.9.2"
 dependencies = [
  "bincode",
  "ibverbs-sys",
- "libc",
+ "nix",
  "serde",
 ]
 
@@ -163,6 +169,18 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"

--- a/ibverbs/Cargo.toml
+++ b/ibverbs/Cargo.toml
@@ -20,6 +20,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 ffi = { path = "../ibverbs-sys", package = "ibverbs-sys", version = "0.3.0" }
+libc = "0.2"
 
 [dependencies.serde]
 version = "1.0.100"

--- a/ibverbs/Cargo.toml
+++ b/ibverbs/Cargo.toml
@@ -20,10 +20,10 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 ffi = { path = "../ibverbs-sys", package = "ibverbs-sys", version = "0.3.0" }
-nix = { version = "0.29", default-features = false, features = ["fs", "poll"] }
+nix = { version = "0.29.0", default-features = false, features = ["fs", "poll"] }
 
 [dependencies.serde]
-version = "1"
+version = "1.0.100"
 optional = true
 features = ["derive"]
 

--- a/ibverbs/Cargo.toml
+++ b/ibverbs/Cargo.toml
@@ -20,10 +20,10 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 ffi = { path = "../ibverbs-sys", package = "ibverbs-sys", version = "0.3.0" }
-libc = "0.2"
+nix = { version = "0.29", default-features = false, features = ["fs", "poll"] }
 
 [dependencies.serde]
-version = "1.0.100"
+version = "1"
 optional = true
 features = ["derive"]
 

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -644,7 +644,7 @@ impl<'ctx> CompletionQueue<'ctx> {
             }
 
             assert_eq!(self.cq, out_cq);
-            // cq_context is the opaque user defined identifier passed to `ibv_create_cq()``.
+            // cq_context is the opaque user defined identifier passed to `ibv_create_cq()`.
             assert!(out_cq_context.is_null());
 
             // All completion events returned by ibv_get_cq_event() must eventually be acknowledged with ibv_ack_cq_events().

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -608,7 +608,7 @@ impl<'ctx> CompletionQueue<'ctx> {
                 timeout
                     .map(nix::poll::PollTimeout::try_from)
                     .transpose()
-                    .map_err(|_| io::Error::other("failedd to convert timeout to PollTimeout"))?,
+                    .map_err(|_| io::Error::other("failed to convert timeout to PollTimeout"))?,
             )?;
             match ret {
                 0 => {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -625,7 +625,7 @@ impl<'ctx> CompletionQueue<'ctx> {
                     ))
                 }
                 1 => {}
-                _ => unreachable!(),
+                _ => unreachable!("we passed 1 fd to poll, but it returned {ret}"),
             }
 
             let mut out_cq = std::ptr::null_mut();


### PR DESCRIPTION
Waits for one or more work completions in a Completion Queue (CQ). This is useful to avoid spin-looping in low-traffic scenarios