### PR TITLE
requery git before creating qp

### DIFF
--- a/ibverbs/examples/loopback.rs
+++ b/ibverbs/examples/loopback.rs
@@ -12,11 +12,12 @@ fn main() {
 
     let qp_builder = pd
         .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_RC)
+        .unwrap()
         .set_gid_index(1)
         .build()
         .unwrap();
 
-    let endpoint = qp_builder.endpoint();
+    let endpoint = qp_builder.endpoint().unwrap();
     let mut qp = qp_builder.handshake(endpoint).unwrap();
 
     let mut mr = pd.allocate::<u64>(2).unwrap();


### PR DESCRIPTION
I found that the git table can change over the lifetime of an ibvcontext, so the port attrs need to be requeried. this pr fixes that. 

it is a breaking change, so a new major version needs to be released. maybe we can bundle a few more changes before releasing the new major version.