### PR TITLE
Expose service level in qp builder

### DIFF
--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -825,7 +825,7 @@ impl QueuePairBuilder {
     }
 
     /// Set the service level of the new `QueuePair`.
-    ///
+    /// service level (0-15). Higher value means higher priority.
     /// Defaults to 0.
     pub fn set_service_level(&mut self, service_level: u8) -> &mut Self {
         self.service_level = service_level;


### PR DESCRIPTION
The Service Level (SL) is the primary method for setting packet priority in InfiniBand. Higher value means higher priority. 

This PR exposes a method to configure in qp builder. Example:

```python
let qp_builder = pd
    .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_RC)
    .unwrap()
    .set_gid_index(get_gid_index(&ctx).unwrap())
    .allow_remote_rw() // Allow remote read/write
    .set_max_send_wr(16)
    .set_max_recv_wr(16)
    .set_service_level(15)
    .build()
    .unwrap();
``` 