### PR TITLE
Add `#[must_use]` attributes to prevent accidental misuse

### DIFF
--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -123,6 +123,7 @@ pub fn devices() -> io::Result<DeviceList> {
 }
 
 /// List of available RDMA devices.
+#[must_use]
 pub struct DeviceList(&'static mut [*mut ffi::ibv_device]);
 
 unsafe impl Sync for DeviceList {}
@@ -380,6 +381,7 @@ unsafe impl Sync for ContextInner {}
 unsafe impl Send for ContextInner {}
 
 /// An RDMA context bound to a device.
+#[must_use]
 pub struct Context {
     inner: Arc<ContextInner>,
 }
@@ -530,6 +532,7 @@ unsafe impl Send for CompletionQueueInner {}
 unsafe impl Sync for CompletionQueueInner {}
 
 /// A completion queue that allows subscribing to the completion of queued sends and receives.
+#[must_use]
 pub struct CompletionQueue {
     inner: Arc<CompletionQueueInner>,
 }
@@ -1644,6 +1647,7 @@ unsafe impl Sync for ProtectionDomainInner {}
 unsafe impl Send for ProtectionDomainInner {}
 
 /// A protection domain for a device's context.
+#[must_use]
 pub struct ProtectionDomain {
     inner: Arc<ProtectionDomainInner>,
 }
@@ -1835,6 +1839,7 @@ impl ProtectionDomain {
 /// which is maintained by the network stack and doesn't have a physical resource behind it. A QP
 /// is a resource of an RDMA device and a QP number can be used by one process at the same time
 /// (similar to a socket that is associated with a specific TCP or UDP port number)
+#[must_use = "QueuePair is immediately destroyed via drop() unless assigned to a variable"]
 pub struct QueuePair {
     pd: Arc<ProtectionDomainInner>,
     qp: *mut ffi::ibv_qp,


### PR DESCRIPTION
My code had a bug where I did
```rust
client_qp.handshake(server_qp_endpoint)?;
```
instead of
```rust
let _qp = client_qp.handshake(server_qp_endpoint)?;
```
This destroyed the queue pair before the RDMA transfer could complete. With this PR applied, a compiler error would have been shown, saving me time debugging:
```
warning: unused `QueuePair` that must be used
  --> client/src/main.rs:40:5
   |
40 |     client_qp.handshake(server_qp_endpoint)?;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: QueuePair is immediately destroyed via drop() unless assigned to a variable
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
40 |     let _ = client_qp.handshake(server_qp_endpoint)?;
   |     +++++++
```

Beside `QueuePair`, I also added `#[must_use]` to other structs I thought it made sense for. This may not be an exhaustive enumeration.