### PR TITLE
Add convenient struct wrappers for buffer pooling

### DIFF
--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2137,11 +2137,14 @@ impl QueuePair {
         locals: &mut [LocalMemorySlice],
         remotes: &[RemoteMemorySlice],
     ) -> Option<(usize, io::Error)> {
-        if wrids_locals_imms.len() != remotes.len() {
+        if wrids_imms_imms.len() != remotes.len() {
+            return Some((0, io::Error::from(io::ErrorKind::InvalidInput)));
+        }
+        if locals.len() != remotes.len() {
             return Some((0, io::Error::from(io::ErrorKind::InvalidInput)));
         }
 
-        let num_wrs = std::cmp::min(wrids_locals_imms.len(), DOORBELL_BATCH_LIMIT);
+        let num_wrs = std::cmp::min(wrids_imms.len(), DOORBELL_BATCH_LIMIT);
         let mut wrs = [ffi::ibv_send_wr::default(); DOORBELL_BATCH_LIMIT];
         let base_wr_ptr = wrs.as_mut_ptr();
         for (((((idx, wr), (wr_id, imm_data)), local), remote)) in wrs

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1536,6 +1536,10 @@ impl<T> MemoryRegion<T> {
         &mut self.data
     }
 
+    fn inner_immut(&self) -> &T {
+        &self.data
+    }
+
     /// Make a subslice of this memory region.
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
         let (addr, length) = calc_addr_len(
@@ -1586,7 +1590,7 @@ impl MemorySlicer {
 pub struct OwnedMemoryRegion<T: AsRef<[u8]> + AsMut<[u8]>>(MemoryRegion<T>);
 impl<T: AsRef<[u8]> + AsMut<[u8]>> AsRef<[u8]> for OwnedMemoryRegion<T> {
     fn as_ref(&self) -> &[u8] {
-        self.0.inner().as_ref()
+        self.0.inner_immut().as_ref()
     }
 }
 impl<T: AsRef<[u8]> + AsMut<[u8]>> AsMut<[u8]> for OwnedMemoryRegion<T> {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1587,6 +1587,18 @@ impl MemorySlicer {
     }
 }
 
+pub struct OwnedMemoryRegion<T: AsRef<[u8]> + AsMut<[u8]>>(MemoryRegion<T>);
+impl<T: AsRef<[u8]> + AsMut<[u8]>> AsRef<[u8]> for OwnedMemoryRegion<T> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.inner().as_ref()
+    }
+}
+impl<T: AsRef<[u8]> + AsMut<[u8]>> AsMut<[u8]> for OwnedMemoryRegion<T> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.inner().as_mut()
+    }
+}
+
 /// Local memory slice.
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(transparent)]

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -77,7 +77,7 @@ use std::time::Duration;
 
 const PORT_NUM: u8 = 1;
 
-const DOORBELL_BATCH_LIMIT: usize = 32;
+pub const DOORBELL_BATCH_LIMIT: usize = 32;
 
 /// Direct access to low-level libverbs FFI.
 pub use ffi::ibv_gid_type;

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2137,7 +2137,7 @@ impl QueuePair {
         locals: &mut [LocalMemorySlice],
         remotes: &[RemoteMemorySlice],
     ) -> Option<(usize, io::Error)> {
-        if wrids_imms_imms.len() != remotes.len() {
+        if wrids_imms.len() != remotes.len() {
             return Some((0, io::Error::from(io::ErrorKind::InvalidInput)));
         }
         if locals.len() != remotes.len() {
@@ -2147,7 +2147,7 @@ impl QueuePair {
         let num_wrs = std::cmp::min(wrids_imms.len(), DOORBELL_BATCH_LIMIT);
         let mut wrs = [ffi::ibv_send_wr::default(); DOORBELL_BATCH_LIMIT];
         let base_wr_ptr = wrs.as_mut_ptr();
-        for (((((idx, wr), (wr_id, imm_data)), local), remote)) in wrs
+        for ((((idx, wr), (wr_id, imm_data)), local), remote) in wrs
             .iter_mut()
             .enumerate()
             .zip(wrids_imms)
@@ -2227,7 +2227,7 @@ impl QueuePair {
         let num_wrs = std::cmp::min(wrids_imms.len(), DOORBELL_BATCH_LIMIT);
         let mut wrs = [ffi::ibv_send_wr::default(); DOORBELL_BATCH_LIMIT];
         let base_wr_ptr = wrs.as_mut_ptr();
-        for (((((idx, wr), (wr_id, imm_data)), local), remote)) in wrs
+        for ((((idx, wr), (wr_id, imm_data)), local), remote) in wrs
             .iter_mut()
             .enumerate()
             .zip(wrids_imms)

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1606,6 +1606,8 @@ impl RemoteMemoryRegion {
 /// Remote memory slice.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct RemoteMemorySlice {
+    /// Memory address of the registered region. Visible to enable user bookkeeping for
+    /// doorbell batching.
     pub addr: u64,
     #[allow(unused)]
     length: u32,

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2123,7 +2123,7 @@ impl QueuePair {
                 } else {
                     ptr::null::<ffi::ibv_send_wr>() as *mut _
                 },
-                sg_list: local as *mut ffi::ibv_sge,
+                sg_list: local as *mut LocalMemorySlice as *mut ffi::ibv_sge,
                 num_sge: 1i32,
                 opcode,
                 send_flags: ffi::ibv_send_flags::IBV_SEND_SIGNALED.0,

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1552,11 +1552,11 @@ impl<T> MemoryRegion<T> {
     }
 
     pub fn mk_slicer(&self) -> MemorySlicer {
-        MemorySlicer {
-            addr: unsafe { *self.mr }.addr as u64,
-            bytes_len: unsafe { *self.mr }.length,
-            lkey: unsafe { *self.mr }.lkey,
-        }
+        MemorySlicer::new(
+            unsafe { *self.mr }.addr as u64,
+            unsafe { *self.mr }.length,
+            unsafe { *self.mr }.lkey,
+        )
     }
 }
 
@@ -1568,6 +1568,13 @@ pub struct MemorySlicer {
     lkey: u32,
 }
 impl MemorySlicer {
+    pub fn new(addr: u64, bytes_len: usize, lkey: u32) -> Self {
+        Self {
+            addr,
+            bytes_len,
+            lkey,
+        }
+    }
     /// Make a subslice of this memory region.
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
         let (addr, length) = calc_addr_len(bounds, self.addr, self.bytes_len);

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2086,7 +2086,7 @@ impl QueuePair {
     pub fn post_one_sided_batch_single_type(
         &mut self,
         is_read: bool,
-        wrids_locals_imms: &[(u64, &[LocalMemorySlice], Option<u32>)],
+        wrids_locals_imms: &[(u64, Vec<LocalMemorySlice>, Option<u32>)],
         remotes: &[RemoteMemorySlice],
     ) -> Option<(usize, io::Error)> {
         if wrids_locals_imms.len() != remotes.len() {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2081,9 +2081,9 @@ impl QueuePair {
         is_read: bool,
         wrids_locals_imms: &[(u64, &[LocalMemorySlice], Option<u32>)],
         remotes: &[RemoteMemorySlice],
-    ) -> Option<(isize, io::Error)> {
+    ) -> Option<(usize, io::Error)> {
         if wrids_locals_imms.len() != remotes.len() {
-            return Err(io::Error::from(io::ErrorKind::InvalidInput));
+            return Err((0, io::Error::from(io::ErrorKind::InvalidInput)));
         }
 
         let mut wrs = vec![ffi::ibv_send_wr::default(); wrids_locals_imms.len()];
@@ -2138,7 +2138,7 @@ impl QueuePair {
             ops.post_send.as_mut().unwrap()(self.qp, wrs.as_mut_ptr(), &mut bad_wr as *mut _)
         };
         if errno != 0 {
-            let bad_idx = unsafe { bad_wr.offset_from(wrs.as_ptr()) };
+            let bad_idx = unsafe { bad_wr.offset_from(wrs.as_ptr()) } as usize;
             Some((bad_idx, io::Error::from_raw_os_error(errno)))
         } else {
             None

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2083,7 +2083,7 @@ impl QueuePair {
         remotes: &[RemoteMemorySlice],
     ) -> Option<(usize, io::Error)> {
         if wrids_locals_imms.len() != remotes.len() {
-            return Err((0, io::Error::from(io::ErrorKind::InvalidInput)));
+            return Some((0, io::Error::from(io::ErrorKind::InvalidInput)));
         }
 
         let mut wrs = vec![ffi::ibv_send_wr::default(); wrids_locals_imms.len()];

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1604,7 +1604,7 @@ impl RemoteMemoryRegion {
 /// Remote memory slice.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct RemoteMemorySlice {
-    addr: u64,
+    pub addr: u64,
     #[allow(unused)]
     length: u32,
     rkey: u32,

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2107,7 +2107,7 @@ impl QueuePair {
             };
 
             *wr = ffi::ibv_send_wr {
-                wr_id,
+                wr_id: *wr_id,
                 next: if idx < wrs.len() - 1 {
                     &mut wrs[idx + 1] as *mut ffi::ibv_send_wr
                 } else {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2086,6 +2086,81 @@ impl QueuePair {
     pub fn post_one_sided_batch_single_type(
         &mut self,
         is_read: bool,
+        wrids_locals_imms: &mut [(u64, LocalMemorySlice, Option<u32>)],
+        remotes: &[RemoteMemorySlice],
+    ) -> Option<(usize, io::Error)> {
+        if wrids_locals_imms.len() != remotes.len() {
+            return Some((0, io::Error::from(io::ErrorKind::InvalidInput)));
+        }
+
+        let num_wrs = std::cmp::min(wrids_locals_imms.len(), DOORBELL_BATCH_LIMIT);
+        let mut wrs = [ffi::ibv_send_wr::default(); DOORBELL_BATCH_LIMIT];
+        let base_wr_ptr = wrs.as_mut_ptr();
+        for (((idx, wr), (wr_id, local, imm_data)), remote) in wrs
+            .iter_mut()
+            .enumerate()
+            .zip(wrids_locals_imms.iter_mut())
+            .zip(remotes)
+            .take(num_wrs)
+        {
+            let (opcode, anon_1) = if is_read {
+                (ffi::ibv_wr_opcode::IBV_WR_RDMA_READ, Default::default())
+            } else if let Some(imm_data) = imm_data {
+                (
+                    ffi::ibv_wr_opcode::IBV_WR_RDMA_WRITE_WITH_IMM,
+                    ffi::ibv_send_wr__bindgen_ty_1 {
+                        imm_data: imm_data.to_be(),
+                    },
+                )
+            } else {
+                (ffi::ibv_wr_opcode::IBV_WR_RDMA_WRITE, Default::default())
+            };
+
+            *wr = ffi::ibv_send_wr {
+                wr_id: *wr_id,
+                next: if idx < num_wrs - 1 {
+                    unsafe { base_wr_ptr.add(idx + 1) }
+                } else {
+                    ptr::null::<ffi::ibv_send_wr>() as *mut _
+                },
+                sg_list: local as *mut ffi::ibv_sge,
+                num_sge: 1i32,
+                opcode,
+                send_flags: ffi::ibv_send_flags::IBV_SEND_SIGNALED.0,
+                wr: ffi::ibv_send_wr__bindgen_ty_2 {
+                    rdma: ffi::ibv_send_wr__bindgen_ty_2__bindgen_ty_1 {
+                        remote_addr: remote.addr,
+                        rkey: remote.rkey,
+                    },
+                },
+                qp_type: Default::default(),
+                __bindgen_anon_1: anon_1,
+                __bindgen_anon_2: Default::default(),
+            };
+        }
+        let mut bad_wr: *mut ffi::ibv_send_wr = ptr::null::<ffi::ibv_send_wr>() as *mut _;
+
+        let ctx = unsafe { *self.qp }.context;
+        let ops = &mut unsafe { *ctx }.ops;
+        let errno =
+            unsafe { ops.post_send.as_mut().unwrap()(self.qp, base_wr_ptr, &mut bad_wr as *mut _) };
+        if errno != 0 {
+            let bad_idx = unsafe { bad_wr.offset_from(wrs.as_ptr()) } as usize;
+            Some((bad_idx, io::Error::from_raw_os_error(errno)))
+        } else {
+            None
+        }
+    }
+
+    /// Post multiple one-sided requests of the same type (i.e., all WRITE
+    /// or all READ) at once, exploiting doorbell batching, up to `DOORBELL_BATCH_LIMIT`
+    /// at a time.
+    /// On success, returns None, else, on failure, returns the error message and
+    /// the index of the first request that failed to be posted (all prior ones
+    /// were successfully posted).
+    pub fn post_one_sided_batch_single_type_vectored(
+        &mut self,
+        is_read: bool,
         wrids_locals_imms: &[(u64, Vec<LocalMemorySlice>, Option<u32>)],
         remotes: &[RemoteMemorySlice],
     ) -> Option<(usize, io::Error)> {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -77,6 +77,8 @@ use std::time::Duration;
 
 const PORT_NUM: u8 = 1;
 
+/// The doorbell batching API(s) will process only up to these many work requests at a time
+/// to prevent inefficient dynamic heap allocations.
 pub const DOORBELL_BATCH_LIMIT: usize = 32;
 
 /// Direct access to low-level libverbs FFI.

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1587,7 +1587,7 @@ impl MemorySlicer {
 
 /// A `MemoryRegion` with buffer (slice) semantics, convenient to pass in to a buffer pool structure
 /// to own.
-pub struct OwnedMemoryRegion<T: AsRef<[u8]> + AsMut<[u8]>>(MemoryRegion<T>);
+pub struct OwnedMemoryRegion<T: AsRef<[u8]> + AsMut<[u8]>>(pub MemoryRegion<T>);
 impl<T: AsRef<[u8]> + AsMut<[u8]>> AsRef<[u8]> for OwnedMemoryRegion<T> {
     fn as_ref(&self) -> &[u8] {
         self.0.inner_immut().as_ref()

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2128,8 +2128,6 @@ impl QueuePair {
                 __bindgen_anon_2: Default::default(),
             };
         }
-        let ctx = unsafe { *self.qp }.context;
-        let ops = &mut unsafe { *ctx }.ops;
         let mut bad_wr: *mut ffi::ibv_send_wr = ptr::null::<ffi::ibv_send_wr>() as *mut _;
 
         let ctx = unsafe { *self.qp }.context;

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2070,6 +2070,80 @@ impl QueuePair {
             Ok(())
         }
     }
+
+    /// Post multiple one-sided requests of the same type (i.e., all WRITE
+    /// or all READ) at once, exploiting doorbell batching.
+    /// On success, returns None, else, on failure, returns the error message and
+    /// the index of the first request that failed to be posted (all prior ones
+    /// were successfully posted).
+    pub fn post_one_sided_batch_single_type(
+        &mut self,
+        is_read: bool,
+        wrids_locals_imms: &[(u64, &[LocalMemorySlice], Option<u32>)],
+        remotes: &[RemoteMemorySlice],
+    ) -> Option<(isize, io::Error)> {
+        if wrids_locals_imms.len() != remotes.len() {
+            return Err(io::Error::from(io::ErrorKind::InvalidInput));
+        }
+
+        let mut wrs = vec![ffi::ibv_send_wr::default(); wrids_locals_imms.len()];
+        for (((idx, wr), (wr_id, local, imm_data)), remote) in wrs
+            .iter_mut()
+            .enumerate()
+            .zip(wrids_locals_imms)
+            .zip(remotes)
+        {
+            let (opcode, anon_1) = if is_read {
+                (ffi::ibv_wr_opcode::IBV_WR_RDMA_READ, Default::default())
+            } else if let Some(imm_data) = imm_data {
+                (
+                    ffi::ibv_wr_opcode::IBV_WR_RDMA_WRITE_WITH_IMM,
+                    ffi::ibv_send_wr__bindgen_ty_1 {
+                        imm_data: imm_data.to_be(),
+                    },
+                )
+            } else {
+                (ffi::ibv_wr_opcode::IBV_WR_RDMA_WRITE, Default::default())
+            };
+
+            *wr = ffi::ibv_send_wr {
+                wr_id,
+                next: if idx < wrs.len() - 1 {
+                    &mut wrs[idx + 1] as *mut ffi::ibv_send_wr
+                } else {
+                    ptr::null::<ffi::ibv_send_wr>() as *mut _
+                },
+                sg_list: local.as_ptr() as *mut ffi::ibv_sge,
+                num_sge: local.len() as i32,
+                opcode,
+                send_flags: ffi::ibv_send_flags::IBV_SEND_SIGNALED.0,
+                wr: ffi::ibv_send_wr__bindgen_ty_2 {
+                    rdma: ffi::ibv_send_wr__bindgen_ty_2__bindgen_ty_1 {
+                        remote_addr: remote.addr,
+                        rkey: remote.rkey,
+                    },
+                },
+                qp_type: Default::default(),
+                __bindgen_anon_1: anon_1,
+                __bindgen_anon_2: Default::default(),
+            };
+        }
+        let ctx = unsafe { *self.qp }.context;
+        let ops = &mut unsafe { *ctx }.ops;
+        let mut bad_wr: *mut ffi::ibv_send_wr = ptr::null::<ffi::ibv_send_wr>() as *mut _;
+
+        let ctx = unsafe { *self.qp }.context;
+        let ops = &mut unsafe { *ctx }.ops;
+        let errno = unsafe {
+            ops.post_send.as_mut().unwrap()(self.qp, wrs.as_mut_ptr(), &mut bad_wr as *mut _)
+        };
+        if errno != 0 {
+            let bad_idx = unsafe { bad_wr.offset_from(wrs.as_ptr()) };
+            Some((bad_idx, io::Error::from_raw_os_error(errno)))
+        } else {
+            None
+        }
+    }
 }
 
 impl Drop for QueuePair {


### PR DESCRIPTION
Add OwnedMemoryRegion and separate MemorySlicer to allow slicing while MemoryRegion is already owned.