### PR TITLE
Add EFA support to rust-ibverbs with working example.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,42 +3,12 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
 ]
 
 [[package]]
@@ -75,12 +45,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bytes"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -139,12 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,7 +116,6 @@ dependencies = [
  "ibverbs-sys",
  "nix",
  "serde",
- "tokio",
 ]
 
 [[package]]
@@ -168,17 +125,6 @@ dependencies = [
  "bindgen",
  "cmake",
  "proc-macro2",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -207,15 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,26 +169,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "nix"
@@ -274,44 +191,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "prettyplease"
@@ -339,15 +218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -380,22 +250,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -424,37 +282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,71 +293,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
-dependencies = [
- "backtrace",
- "bytes",
- "io-uring",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "slab",
- "socket2",
- "tokio-macros",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ version = "0.3.2+55.0"
 dependencies = [
  "bindgen",
  "cmake",
+ "libloading",
  "proc-macro2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,42 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -45,6 +75,12 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -103,6 +139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +158,7 @@ dependencies = [
  "ibverbs-sys",
  "nix",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -125,6 +168,17 @@ dependencies = [
  "bindgen",
  "cmake",
  "proc-macro2",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -153,6 +207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +232,26 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nix"
@@ -191,6 +274,44 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "prettyplease"
@@ -218,6 +339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -250,10 +380,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -282,6 +424,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,10 +466,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-targets"

--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -26,6 +26,9 @@ exclude = ["vendor/rdma-core/build/"]
 [features]
 efa = []
 
+[dependencies]
+libloading = "0.8"
+
 [build-dependencies]
 bindgen = "0.71.1"
 cmake = "0.1.50"

--- a/ibverbs-sys/Cargo.toml
+++ b/ibverbs-sys/Cargo.toml
@@ -23,6 +23,9 @@ license = "MIT OR Apache-2.0"
 
 exclude = ["vendor/rdma-core/build/"]
 
+[features]
+efa = []
+
 [build-dependencies]
 bindgen = "0.71.1"
 cmake = "0.1.50"

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -8,9 +8,9 @@ fn main() {
     println!("cargo:rustc-link-search=native={manifest_dir}/vendor/rdma-core/build/lib");
     println!("cargo:rustc-link-lib=ibverbs");
 
-    // Link EFA library when the feature is enabled
-    if env::var("CARGO_FEATURE_EFA").is_ok() {
+    if env::var("CARGO_FEATURE_EFA").is_ok() && Path::new("/opt/amazon/efa/lib/").exists() {
         println!("cargo:rustc-link-lib=efa");
+        println!("cargo:rustc-cfg=feature=\"efa\"");
     }
 
     if Path::new("vendor/rdma-core/CMakeLists.txt").exists() {

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -8,11 +8,6 @@ fn main() {
     println!("cargo:rustc-link-search=native={manifest_dir}/vendor/rdma-core/build/lib");
     println!("cargo:rustc-link-lib=ibverbs");
 
-    if env::var("CARGO_FEATURE_EFA").is_ok() && Path::new("/opt/amazon/efa/lib/").exists() {
-        println!("cargo:rustc-link-lib=efa");
-        println!("cargo:rustc-cfg=feature=\"efa\"");
-    }
-
     if Path::new("vendor/rdma-core/CMakeLists.txt").exists() {
         // don't touch source dir if not necessary
     } else if Path::new(".git").is_dir() {
@@ -72,6 +67,7 @@ fn main() {
         .allowlist_function("ibv_wc_read_imm_data")
         .allowlist_function("ibv_wr_rdma_write_imm")
         .allowlist_function("ibv_wr_rdma_write")
+        .allowlist_function("ibv_wr_send")
         .allowlist_function("ibv_wr_rdma_read")
         .allowlist_type("ibv_.*")
         .allowlist_type("efa.*")

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -7,8 +7,9 @@ fn main() {
     println!("cargo:include={manifest_dir}/vendor/rdma-core/build/include");
     println!("cargo:rustc-link-search=native={manifest_dir}/vendor/rdma-core/build/lib");
     println!("cargo:rustc-link-lib=ibverbs");
-    // Only link EFA if the library exists (i.e., on EFA-capable hosts)
-    if Path::new("/opt/amazon/efa/lib/").exists() {
+
+    // Link EFA library when the feature is enabled
+    if env::var("CARGO_FEATURE_EFA").is_ok() {
         println!("cargo:rustc-link-lib=efa");
     }
 

--- a/ibverbs-sys/build.rs
+++ b/ibverbs-sys/build.rs
@@ -7,6 +7,10 @@ fn main() {
     println!("cargo:include={manifest_dir}/vendor/rdma-core/build/include");
     println!("cargo:rustc-link-search=native={manifest_dir}/vendor/rdma-core/build/lib");
     println!("cargo:rustc-link-lib=ibverbs");
+    // Only link EFA if the library exists (i.e., on EFA-capable hosts)
+    if Path::new("/opt/amazon/efa/lib/").exists() {
+        println!("cargo:rustc-link-lib=efa");
+    }
 
     if Path::new("vendor/rdma-core/CMakeLists.txt").exists() {
         // don't touch source dir if not necessary
@@ -50,11 +54,28 @@ fn main() {
     eprintln!("run bindgen");
     let bindings = bindgen::Builder::default()
         .header("vendor/rdma-core/libibverbs/verbs.h")
+        .header("vendor/rdma-core/providers/efa/efadv.h")
         .clang_arg(format!("-I{built_in}/include/"))
         .allowlist_function("ibv_.*")
         .allowlist_function("_ibv_.*")
+        .allowlist_function("efadv_.*")
+        .allowlist_function("ibv_cq_ex_to_cq")
+        .allowlist_function("ibv_start_poll")
+        .allowlist_type("ibv_cq_ex")
+        .allowlist_type("ibv_poll_cq_attr")
+        .allowlist_function("ibv_next_poll")
+        .allowlist_function("ibv_end_poll")
+        .allowlist_function("ibv_wc_read_opcode")
+        .allowlist_function("ibv_wc_read_vendor_err")
+        .allowlist_function("ibv_wc_read_byte_len")
+        .allowlist_function("ibv_wc_read_imm_data")
+        .allowlist_function("ibv_wr_rdma_write_imm")
+        .allowlist_function("ibv_wr_rdma_write")
+        .allowlist_function("ibv_wr_rdma_read")
         .allowlist_type("ibv_.*")
+        .allowlist_type("efa.*")
         .allowlist_var("IBV_LINK_LAYER_.*")
+        .allowlist_var("EFADV_QP_DRIVER_TYPE_.*")
         .bitfield_enum("ibv_access_flags")
         .bitfield_enum("ibv_create_cq_wc_flags")
         .bitfield_enum("ibv_device_cap_flags")
@@ -64,6 +85,7 @@ fn main() {
         .bitfield_enum("ibv_qp_attr_mask")
         .bitfield_enum("ibv_qp_create_send_ops_flags")
         .bitfield_enum("ibv_qp_init_attr_mask")
+        .bitfield_enum("ibv_qp_init_attr_ex_mask")
         .bitfield_enum("ibv_qp_open_attr_mask")
         .bitfield_enum("ibv_raw_packet_caps")
         .bitfield_enum("ibv_rx_hash_fields")

--- a/ibverbs-sys/src/lib.rs
+++ b/ibverbs-sys/src/lib.rs
@@ -5,7 +5,54 @@
 // Suppress expected warnings from bindgen-generated code.
 // See https://github.com/rust-lang/rust-bindgen/issues/1651.
 #![allow(deref_nullptr)]
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+// Dynamic EFA loading module
+#[cfg(feature = "efa")]
+mod efa_dynamic {
+    use libloading::{Library, Symbol};
+    use std::sync::OnceLock;
+
+    static EFA_LIBRARY: OnceLock<Result<Library, libloading::Error>> = OnceLock::new();
+
+    fn load_efa_library() -> Result<&'static Library, &'static libloading::Error> {
+        EFA_LIBRARY.get_or_init(|| {
+            unsafe { Library::new("libefa.so") }
+        }).as_ref()
+    }
+
+    // Function pointer types for EFA functions
+    type EfadvCreateQpExFn = unsafe extern "C" fn(
+        ibv_ctx: *mut crate::ibv_context,
+        attr: *mut crate::ibv_qp_init_attr_ex,
+        efa_attr: *mut crate::efadv_qp_init_attr,
+        efa_attr_size: u32,
+    ) -> *mut crate::ibv_qp;
+
+    // Lazy-loaded EFA functions
+    pub struct EfaFunctions {
+        pub efadv_create_qp_ex: Symbol<'static, EfadvCreateQpExFn>,
+    }
+
+    impl EfaFunctions {
+        pub fn load() -> Result<Self, String> {
+            let lib = load_efa_library().map_err(|e| format!("Failed to load EFA library: {}", e))?;
+
+            unsafe {
+                Ok(Self {
+                    efadv_create_qp_ex: lib.get(b"efadv_create_qp_ex").map_err(|e| format!("Failed to load efadv_create_qp_ex: {}", e))?,
+                })
+            }
+        }
+    }
+
+    static EFA_FUNCTIONS: OnceLock<Result<EfaFunctions, String>> = OnceLock::new();
+
+    pub fn get_efa_functions() -> Result<&'static EfaFunctions, &'static String> {
+        EFA_FUNCTIONS.get_or_init(|| EfaFunctions::load()).as_ref()
+    }
+}
 
 /// An ibverb work completion.
 #[repr(C)]

--- a/ibverbs-sys/src/lib.rs
+++ b/ibverbs-sys/src/lib.rs
@@ -54,6 +54,9 @@ mod efa_dynamic {
     }
 }
 
+#[cfg(feature = "efa")]
+pub use efa_dynamic::get_efa_functions;
+
 /// An ibverb work completion.
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/ibverbs/Cargo.toml
+++ b/ibverbs/Cargo.toml
@@ -20,7 +20,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 ffi = { path = "../ibverbs-sys", package = "ibverbs-sys", version = "0.3.0" }
-nix = { version = "0.29.0", default-features = false, features = ["fs", "poll"] }
+nix = { version = "0.29.0", default-features = false, features = ["fs", "poll", "mman", "feature"] }
 
 [dependencies.serde]
 version = "1.0.100"
@@ -32,3 +32,4 @@ default = ["serde"]
 
 [dev-dependencies]
 bincode = "1.3"
+tokio = { version = "1.0", features = ["full"] }

--- a/ibverbs/Cargo.toml
+++ b/ibverbs/Cargo.toml
@@ -29,6 +29,7 @@ features = ["derive"]
 
 [features]
 default = ["serde"]
+efa = ["ffi/efa"]
 
 [dev-dependencies]
 bincode = "1.3"

--- a/ibverbs/Cargo.toml
+++ b/ibverbs/Cargo.toml
@@ -32,4 +32,3 @@ default = ["serde"]
 
 [dev-dependencies]
 bincode = "1.3"
-tokio = { version = "1.0", features = ["full"] }

--- a/ibverbs/examples/efa_read.rs
+++ b/ibverbs/examples/efa_read.rs
@@ -1,4 +1,6 @@
 //! EFA Read Example
+//! 
+//! Run with `cargo run --example efa_read --features efa`
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Starting EFA one-sided read example with separate reader/writer tasks...");

--- a/ibverbs/examples/efa_read.rs
+++ b/ibverbs/examples/efa_read.rs
@@ -1,54 +1,46 @@
-//! EFA Write Example
-//! 
-//! Key Notes:
-//! - "handshakes" in SRD is not exactly a handshake. We really just need to create the AHs on 
-//!   both sides and then we can use the AHs to send and receive data. This is because SRD
-//!   is a connectionless protocol. It does not gurantee that both sides are ready.
-//! - We use the QP_EX API to create the QP. This is primarily needed so that we can create an SRD QP.
-//! - All MRs must be registered before the QP is handshaked...
-//! - All post_receives on receiver side must be posted before the writer sends.
-//!   Failure to do so will result in a `IBV_WC_RNR_RETRY_EXC_ERR` error in WCE
-//! - Writes are non ordered. You must not depend on the "last" write with imm data to be received as a
-//!   signal of last write completion.
+//! EFA Read Example
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    println!("Starting EFA one-sided write example with separate sender/receiver tasks...");
+    println!("Starting EFA one-sided read example with separate reader/writer tasks...");
 
-    // Channels to communicate the endpoints between sender and receiver.
-    let (sender_tx, sender_rx) = std::sync::mpsc::channel();
-    let (receiver_tx, receiver_rx) = std::sync::mpsc::channel();
-    // Channels to communicate the remote MRs between sender and receiver.
-    let (sender_remote_mr_tx, sender_remote_mr_rx) = std::sync::mpsc::channel();
-    let (receiver_remote_mr_tx, receiver_remote_mr_rx) = std::sync::mpsc::channel();
-    // Chan to communicate that the receiver is ready to receive data.
-    let (receiver_is_ready_tx, receiver_is_ready_rx) = std::sync::mpsc::channel();
+    // Channels to communicate the endpoints between reader and writer.
+    let (reader_tx, reader_rx) = std::sync::mpsc::channel();
+    let (writer_tx, writer_rx) = std::sync::mpsc::channel();
+    // Channels to communicate the remote MRs between reader and writer.
+    let (reader_remote_mr_tx, reader_remote_mr_rx) = std::sync::mpsc::channel();
+    let (writer_remote_mr_tx, writer_remote_mr_rx) = std::sync::mpsc::channel();
+    // Chan to communicate that the writer is ready with data.
+    let (writer_is_ready_tx, writer_is_ready_rx) = std::sync::mpsc::channel();
+    // Chan to communicate that the reader has finished reading.
+    let (reader_done_tx, reader_done_rx) = std::sync::mpsc::channel();
 
-    // Spawn sender and receiver tasks
-    let sender_handle = std::thread::spawn(move || {
-        sender_task(sender_tx, receiver_rx, sender_remote_mr_tx, receiver_remote_mr_rx, receiver_is_ready_rx)
+    // Spawn reader and writer tasks
+    let reader_handle = std::thread::spawn(move || {
+        reader_task(reader_tx, writer_rx, reader_remote_mr_tx, writer_remote_mr_rx, writer_is_ready_rx, reader_done_tx)
     });
 
-    let receiver_handle = std::thread::spawn(move || {
-        receiver_task(receiver_tx, sender_rx, receiver_remote_mr_tx, sender_remote_mr_rx, receiver_is_ready_tx)
+    let writer_handle = std::thread::spawn(move || {
+        writer_task(writer_tx, reader_rx, writer_remote_mr_tx, reader_remote_mr_rx, writer_is_ready_tx, reader_done_rx)
     });
 
     // Wait for both tasks to complete
-    let sender_result = sender_handle.join().map_err(|_| "Sender thread panicked")?;
-    let receiver_result = receiver_handle.join().map_err(|_| "Receiver thread panicked")?;
+    let reader_result = reader_handle.join().map_err(|_| "Reader thread panicked")?;
+    let writer_result = writer_handle.join().map_err(|_| "Writer thread panicked")?;
 
-    sender_result?;
-    receiver_result?;
+    reader_result?;
+    writer_result?;
 
-    println!("Both sender and receiver tasks completed successfully!");
+    println!("Both reader and writer tasks completed successfully!");
     Ok(())
 }
 
-fn sender_task(
+fn reader_task(
     endpoint_tx: std::sync::mpsc::Sender<ibverbs::QueuePairEndpoint>,
     peer_rx: std::sync::mpsc::Receiver<ibverbs::QueuePairEndpoint>,
     remote_mr_tx: std::sync::mpsc::Sender<ibverbs::RemoteMemorySlice>,
     remote_mr_rx: std::sync::mpsc::Receiver<ibverbs::RemoteMemorySlice>,
-    receiver_is_ready_rx: std::sync::mpsc::Receiver<bool>,
+    writer_is_ready_rx: std::sync::mpsc::Receiver<bool>,
+    reader_done_tx: std::sync::mpsc::Sender<bool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Open RDMA device - assume EFA compatibility
     let ctx = match ibverbs::devices()
@@ -99,14 +91,14 @@ fn sender_task(
     // Move QP to RTR states and create remote AH
     let mut qp = qp_builder.handshake(peer_endpoint).unwrap();
 
-    // Wait for receiver to be ready
-    let receiver_is_ready = receiver_is_ready_rx.recv().unwrap();
-    if !receiver_is_ready {
-        return Err("Receiver is not ready".into());
+    // Wait for writer to be ready with data
+    let writer_is_ready = writer_is_ready_rx.recv().unwrap();
+    if !writer_is_ready {
+        return Err("Writer is not ready".into());
     }
 
-    // Post EFA write with immediate data
-    qp.post_write(&[local_mr.slice(..4096)], remote_mr, 0, Some(0x67)).unwrap();
+    // Post EFA read from remote memory into local memory
+    qp.post_read_efa(&[local_mr.slice(..4096)], remote_mr, peer_endpoint, 0, None).unwrap();
 
     // Wait for completion
     let mut completions = [ibverbs::ibv_wc::default(); 16];
@@ -118,21 +110,31 @@ fn sender_task(
         for wr in completed {
             if wr.wr_id() == 0 {
                 if let Some((wc_code, vendor_err)) = wr.error() {
-                    println!("EFA write failed: wc_code={:?}, vendor_err={:?}", wc_code, vendor_err);
-                    return Err("EFA write failed".into());
+                    println!("EFA read failed: wc_code={:?}, vendor_err={:?}", wc_code, vendor_err);
+                    return Err("EFA read failed".into());
                 }
+                // Check the data that was read
+                let data = local_mr.inner();
+                let read_number = u64::from_le_bytes(data[..8].try_into().unwrap());
+                println!("Read number: {}", read_number);
+
+                // Notify writer that reading is complete
+                reader_done_tx.send(true).unwrap();
+                println!("Reader notified writer of completion");
+
                 return Ok(());
             }
         }
     }
 }
 
-fn receiver_task(
+fn writer_task(
     endpoint_tx: std::sync::mpsc::Sender<ibverbs::QueuePairEndpoint>,
     peer_rx: std::sync::mpsc::Receiver<ibverbs::QueuePairEndpoint>,
     remote_mr_tx: std::sync::mpsc::Sender<ibverbs::RemoteMemorySlice>,
     remote_mr_rx: std::sync::mpsc::Receiver<ibverbs::RemoteMemorySlice>,
-    receiver_is_ready_tx: std::sync::mpsc::Sender<bool>,
+    writer_is_ready_tx: std::sync::mpsc::Sender<bool>,
+    reader_done_rx: std::sync::mpsc::Receiver<bool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Open RDMA device - assume EFA compatibility
     let ctx = match ibverbs::devices()
@@ -172,7 +174,12 @@ fn receiver_task(
         ibverbs::ibv_access_flags::IBV_ACCESS_REMOTE_READ.0
     );
 
-    let local_mr = pd.allocate_with_permissions(4096, efa_access_flags).unwrap();
+    let mut local_mr = pd.allocate_with_permissions(4096, efa_access_flags).unwrap();
+
+    // Write a simple number to the local memory region
+    let test_number: u64 = 42;
+    local_mr.inner_mut()[..std::mem::size_of::<u64>()].copy_from_slice(&test_number.to_le_bytes());
+    println!("Writer prepared test number: {}", test_number);
 
     // Exchange endpoints and memory regions
     endpoint_tx.send(my_endpoint).map_err(|_| "Failed to send endpoint")?;
@@ -181,29 +188,17 @@ fn receiver_task(
     let _remote_mr = remote_mr_rx.recv().unwrap();
 
     // Move QP to RTR states and create remote AH
-    let mut qp = qp_builder.handshake(peer_endpoint).unwrap();
+    let _qp = qp_builder.handshake(peer_endpoint).unwrap();
 
-    // Post receive for the write operation
-    let dummy_buffer = pd.allocate_with_permissions(4096, efa_access_flags).unwrap();
-    unsafe { qp.post_receive(&[dummy_buffer.slice(..)], 1) }.unwrap();
+    // Signal ready to reader
+    writer_is_ready_tx.send(true).unwrap();
 
-    // Signal ready to sender
-    receiver_is_ready_tx.send(true).unwrap();
-
-    // Wait for completion
-    let mut completions = [ibverbs::ibv_wc::default(); 16];
-    loop {
-        let completed = cq.poll(&mut completions[..]).unwrap();
-        if completed.is_empty() {
-            continue;
-        }
-        for wr in completed {
-            if wr.wr_id() == 1 {
-                let imm_data = wr.imm_data();
-                let imm_data_host_order = u32::from_be(imm_data.unwrap());
-                println!("Received immediate data: {} (0x{:08x})", imm_data_host_order, imm_data_host_order);
-                return Ok(());
-            }
-        }
+    // Writer waits for reader to complete reading
+    println!("Writer is ready and waiting for reader to complete...");
+    let reader_done = reader_done_rx.recv().unwrap();
+    if reader_done {
+        println!("Writer received completion notification from reader");
     }
+
+    Ok(())
 }

--- a/ibverbs/examples/efa_write.rs
+++ b/ibverbs/examples/efa_write.rs
@@ -10,6 +10,8 @@
 //!   Failure to do so will result in a `IBV_WC_RNR_RETRY_EXC_ERR` error in WCE
 //! - Writes are non ordered. You must not depend on the "last" write with imm data to be received as a
 //!   signal of last write completion.
+//! 
+//! Run with `cargo run --example efa_write --features efa`
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Starting EFA one-sided write example with separate sender/receiver tasks...");

--- a/ibverbs/examples/efa_write.rs
+++ b/ibverbs/examples/efa_write.rs
@@ -5,7 +5,7 @@
 //!   both sides and then we can use the AHs to send and receive data. This is because SRD
 //!   is a connectionless protocol. It does not gurantee that both sides are ready.
 //! - We use the QP_EX API to create the QP. This is primarily needed so that we can create an SRD QP.
-//! - All MRs must be registered before the QP is created and handshaked...
+//! - All MRs must be registered before the QP is handshaked...
 //! - All post_receives on receiver side must be posted before the writer sends.
 //!   Failure to do so will result in a `IBV_WC_RNR_RETRY_EXC_ERR` error in WCE
 //! - Writes are non ordered. You must not depend on the "last" write with imm data to be received as a
@@ -55,7 +55,7 @@ fn sender_task(
         .unwrap()
         .iter()
         .nth(1) {
-        Some(dev) => dev.open().unwrap(),
+        Some(dev) => dev.open_with_efa().unwrap(),
         None => {
             eprintln!("No RDMA devices found!");
             return Ok(());
@@ -69,7 +69,7 @@ fn sender_task(
     // Create EFA QP
     let qp_builder_result = pd
         .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_DRIVER)
-        .and_then(|mut builder| builder.set_gid_index(0).enable_efa(true).build());
+        .and_then(|mut builder| builder.set_gid_index(0).build());
 
     let qp_builder = match qp_builder_result {
         Ok(builder) => builder,
@@ -139,7 +139,7 @@ fn receiver_task(
         .unwrap()
         .iter()
         .nth(2) {
-        Some(dev) => dev.open().unwrap(),
+        Some(dev) => dev.open_with_efa().unwrap(),
         None => {
             eprintln!("No RDMA devices found!");
             return Ok(());
@@ -153,7 +153,7 @@ fn receiver_task(
     // Create EFA QP
     let qp_builder_result = pd
         .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_DRIVER)
-        .and_then(|mut builder| builder.set_gid_index(0).enable_efa(true).build());
+        .and_then(|mut builder| builder.set_gid_index(0).build());
 
     let qp_builder = match qp_builder_result {
         Ok(builder) => builder,

--- a/ibverbs/examples/efa_write.rs
+++ b/ibverbs/examples/efa_write.rs
@@ -69,7 +69,7 @@ async fn sender_task(
     // Create EFA QP
     let qp_builder_result = pd
         .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_DRIVER)
-        .and_then(|mut builder| builder.set_gid_index(0).build_efa());
+        .and_then(|mut builder| builder.set_gid_index(0).enable_efa(true).build());
 
     let qp_builder = match qp_builder_result {
         Ok(builder) => builder,
@@ -97,7 +97,7 @@ async fn sender_task(
     remote_mr_tx.send(local_mr.remote()).unwrap();
 
     // Move QP to RTR states and create remote AH
-    let mut qp = qp_builder.handshake_efa(peer_endpoint).unwrap();
+    let mut qp = qp_builder.handshake(peer_endpoint).unwrap();
 
     // Wait for receiver to be ready
     let receiver_is_ready = receiver_is_ready_rx.await.unwrap();
@@ -106,7 +106,7 @@ async fn sender_task(
     }
 
     // Post EFA write with immediate data
-    qp.post_write_efa(&[local_mr.slice(..4096)], remote_mr, peer_endpoint, 0, Some(0x67)).unwrap();
+    qp.post_write(&[local_mr.slice(..4096)], remote_mr, 0, Some(0x67)).unwrap();
 
     // Wait for completion
     let mut completions = [ibverbs::ibv_wc::default(); 16];
@@ -153,7 +153,7 @@ async fn receiver_task(
     // Create EFA QP
     let qp_builder_result = pd
         .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_DRIVER)
-        .and_then(|mut builder| builder.set_gid_index(0).build_efa());
+        .and_then(|mut builder| builder.set_gid_index(0).enable_efa(true).build());
 
     let qp_builder = match qp_builder_result {
         Ok(builder) => builder,
@@ -181,7 +181,7 @@ async fn receiver_task(
     let _remote_mr = remote_mr_rx.await.unwrap();
 
     // Move QP to RTR states and create remote AH
-    let mut qp = qp_builder.handshake_efa(peer_endpoint).unwrap();
+    let mut qp = qp_builder.handshake(peer_endpoint).unwrap();
 
     // Post receive for the write operation
     let dummy_buffer = pd.allocate_with_permissions(4096, efa_access_flags).unwrap();

--- a/ibverbs/examples/efa_write.rs
+++ b/ibverbs/examples/efa_write.rs
@@ -1,0 +1,210 @@
+//! EFA Write Example
+//! 
+//! Key Notes:
+//! - "handshakes" in SRD is not exactly a handshake. We really just need to create the AHs on 
+//!   both sides and then we can use the AHs to send and receive data. This is because SRD
+//!   is a connectionless protocol. It does not gurantee that both sides are ready.
+//! - We use the QP_EX API to create the QP. This is primarily needed so that we can create an SRD QP.
+//! - All MRs must be registered before the QP is created and handshaked...
+//! - All post_receives on receiver side must be posted before the writer sends.
+//!   Failure to do so will result in a `IBV_WC_RNR_RETRY_EXC_ERR` error in WCE
+//! - Writes are non ordered. You must not depend on the "last" write with imm data to be received as a
+//!   signal of last write completion.
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    println!("Starting EFA one-sided write example with separate sender/receiver tasks...");
+
+    // Channels to communicate the endpoints between sender and receiver.
+    let (sender_tx, sender_rx) = tokio::sync::oneshot::channel();
+    let (receiver_tx, receiver_rx) = tokio::sync::oneshot::channel();
+    // Channels to communicate the remote MRs between sender and receiver.
+    let (sender_remote_mr_tx, sender_remote_mr_rx) = tokio::sync::oneshot::channel();
+    let (receiver_remote_mr_tx, receiver_remote_mr_rx) = tokio::sync::oneshot::channel();
+    // Chan to communicate that the receiver is ready to receive data.
+    let (receiver_is_ready_tx, receiver_is_ready_rx) = tokio::sync::oneshot::channel();
+
+    // Spawn sender and receiver tasks
+    let sender_handle = tokio::spawn(async move {
+        sender_task(sender_tx, receiver_rx, sender_remote_mr_tx, receiver_remote_mr_rx, receiver_is_ready_rx).await
+    });
+
+    let receiver_handle = tokio::spawn(async move {
+        receiver_task(receiver_tx, sender_rx, receiver_remote_mr_tx, sender_remote_mr_rx, receiver_is_ready_tx).await
+    });
+
+    // Wait for both tasks to complete
+    let (sender_result, receiver_result) = tokio::try_join!(sender_handle, receiver_handle)?;
+
+    sender_result?;
+    receiver_result?;
+
+    println!("Both sender and receiver tasks completed successfully!");
+    Ok(())
+}
+
+async fn sender_task(
+    endpoint_tx: tokio::sync::oneshot::Sender<ibverbs::QueuePairEndpoint>,
+    peer_rx: tokio::sync::oneshot::Receiver<ibverbs::QueuePairEndpoint>,
+    remote_mr_tx: tokio::sync::oneshot::Sender<ibverbs::RemoteMemorySlice>,
+    remote_mr_rx: tokio::sync::oneshot::Receiver<ibverbs::RemoteMemorySlice>,
+    receiver_is_ready_rx: tokio::sync::oneshot::Receiver<bool>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Open RDMA device - assume EFA compatibility
+    let ctx = match ibverbs::devices()
+        .unwrap()
+        .iter()
+        .nth(1) {
+        Some(dev) => dev.open().unwrap(),
+        None => {
+            eprintln!("No RDMA devices found!");
+            return Ok(());
+        }
+    };
+
+    // Create completion queue and protection domain
+    let cq = ctx.create_cq(16, 0).unwrap();
+    let pd = ctx.alloc_pd().unwrap();
+
+    // Create EFA QP
+    let qp_builder_result = pd
+        .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_DRIVER)
+        .and_then(|mut builder| builder.set_gid_index(0).build_efa());
+
+    let qp_builder = match qp_builder_result {
+        Ok(builder) => builder,
+        Err(e) => {
+            println!("EFA QP creation failed: {}. This is expected if EFA is not available.", e);
+            return Ok(());
+        }
+    };
+
+    let my_endpoint = qp_builder.endpoint()?;
+
+    // Allocate and register memory regions
+    let efa_access_flags = ibverbs::ibv_access_flags(
+        ibverbs::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0 |
+        ibverbs::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0 |
+        ibverbs::ibv_access_flags::IBV_ACCESS_REMOTE_READ.0
+    );
+
+    let local_mr = pd.allocate_with_permissions(4096, efa_access_flags).unwrap();
+
+    // Exchange endpoints and memory regions
+    endpoint_tx.send(my_endpoint).map_err(|_| "Failed to send endpoint")?;
+    let peer_endpoint = peer_rx.await.map_err(|_| "Failed to receive peer endpoint")?;
+    let remote_mr = remote_mr_rx.await.unwrap();
+    remote_mr_tx.send(local_mr.remote()).unwrap();
+
+    // Move QP to RTR states and create remote AH
+    let mut qp = qp_builder.handshake_efa(peer_endpoint).unwrap();
+
+    // Wait for receiver to be ready
+    let receiver_is_ready = receiver_is_ready_rx.await.unwrap();
+    if !receiver_is_ready {
+        return Err("Receiver is not ready".into());
+    }
+
+    // Post EFA write with immediate data
+    qp.post_write_efa(&[local_mr.slice(..4096)], remote_mr, peer_endpoint, 0, Some(0x67)).unwrap();
+
+    // Wait for completion
+    let mut completions = [ibverbs::ibv_wc::default(); 16];
+    loop {
+        let completed = cq.poll(&mut completions[..]).unwrap();
+        if completed.is_empty() {
+            continue;
+        }
+        for wr in completed {
+            if wr.wr_id() == 0 {
+                if let Some((wc_code, vendor_err)) = wr.error() {
+                    println!("EFA write failed: wc_code={:?}, vendor_err={:?}", wc_code, vendor_err);
+                    return Err("EFA write failed".into());
+                }
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn receiver_task(
+    endpoint_tx: tokio::sync::oneshot::Sender<ibverbs::QueuePairEndpoint>,
+    peer_rx: tokio::sync::oneshot::Receiver<ibverbs::QueuePairEndpoint>,
+    remote_mr_tx: tokio::sync::oneshot::Sender<ibverbs::RemoteMemorySlice>,
+    remote_mr_rx: tokio::sync::oneshot::Receiver<ibverbs::RemoteMemorySlice>,
+    receiver_is_ready_tx: tokio::sync::oneshot::Sender<bool>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Open RDMA device - assume EFA compatibility
+    let ctx = match ibverbs::devices()
+        .unwrap()
+        .iter()
+        .nth(2) {
+        Some(dev) => dev.open().unwrap(),
+        None => {
+            eprintln!("No RDMA devices found!");
+            return Ok(());
+        }
+    };
+
+    // Create completion queue and protection domain
+    let cq = ctx.create_cq(16, 0).unwrap();
+    let pd = ctx.alloc_pd().unwrap();
+
+    // Create EFA QP
+    let qp_builder_result = pd
+        .create_qp(&cq, &cq, ibverbs::ibv_qp_type::IBV_QPT_DRIVER)
+        .and_then(|mut builder| builder.set_gid_index(0).build_efa());
+
+    let qp_builder = match qp_builder_result {
+        Ok(builder) => builder,
+        Err(e) => {
+            println!("EFA QP creation failed: {}. This is expected if EFA is not available.", e);
+            return Ok(());
+        }
+    };
+
+    let my_endpoint = qp_builder.endpoint()?;
+
+    // Allocate and register memory regions
+    let efa_access_flags = ibverbs::ibv_access_flags(
+        ibverbs::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0 |
+        ibverbs::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0 |
+        ibverbs::ibv_access_flags::IBV_ACCESS_REMOTE_READ.0
+    );
+
+    let local_mr = pd.allocate_with_permissions(4096, efa_access_flags).unwrap();
+
+    // Exchange endpoints and memory regions
+    endpoint_tx.send(my_endpoint).map_err(|_| "Failed to send endpoint")?;
+    let peer_endpoint = peer_rx.await.map_err(|_| "Failed to receive peer endpoint")?;
+    remote_mr_tx.send(local_mr.remote()).unwrap();
+    let _remote_mr = remote_mr_rx.await.unwrap();
+
+    // Move QP to RTR states and create remote AH
+    let mut qp = qp_builder.handshake_efa(peer_endpoint).unwrap();
+
+    // Post receive for the write operation
+    let dummy_buffer = pd.allocate_with_permissions(4096, efa_access_flags).unwrap();
+    unsafe { qp.post_receive(&[dummy_buffer.slice(..)], 1) }.unwrap();
+
+    // Signal ready to sender
+    receiver_is_ready_tx.send(true).unwrap();
+
+    // Wait for completion
+    let mut completions = [ibverbs::ibv_wc::default(); 16];
+    loop {
+        let completed = cq.poll(&mut completions[..]).unwrap();
+        if completed.is_empty() {
+            tokio::task::yield_now().await;
+            continue;
+        }
+        for wr in completed {
+            if wr.wr_id() == 1 {
+                let imm_data = wr.imm_data();
+                let imm_data_host_order = u32::from_be(imm_data.unwrap());
+                println!("Received immediate data: {} (0x{:08x})", imm_data_host_order, imm_data_host_order);
+                return Ok(());
+            }
+        }
+    }
+}

--- a/ibverbs/examples/efa_write.rs
+++ b/ibverbs/examples/efa_write.rs
@@ -11,30 +11,30 @@
 //! - Writes are non ordered. You must not depend on the "last" write with imm data to be received as a
 //!   signal of last write completion.
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Starting EFA one-sided write example with separate sender/receiver tasks...");
 
     // Channels to communicate the endpoints between sender and receiver.
-    let (sender_tx, sender_rx) = tokio::sync::oneshot::channel();
-    let (receiver_tx, receiver_rx) = tokio::sync::oneshot::channel();
+    let (sender_tx, sender_rx) = std::sync::mpsc::channel();
+    let (receiver_tx, receiver_rx) = std::sync::mpsc::channel();
     // Channels to communicate the remote MRs between sender and receiver.
-    let (sender_remote_mr_tx, sender_remote_mr_rx) = tokio::sync::oneshot::channel();
-    let (receiver_remote_mr_tx, receiver_remote_mr_rx) = tokio::sync::oneshot::channel();
+    let (sender_remote_mr_tx, sender_remote_mr_rx) = std::sync::mpsc::channel();
+    let (receiver_remote_mr_tx, receiver_remote_mr_rx) = std::sync::mpsc::channel();
     // Chan to communicate that the receiver is ready to receive data.
-    let (receiver_is_ready_tx, receiver_is_ready_rx) = tokio::sync::oneshot::channel();
+    let (receiver_is_ready_tx, receiver_is_ready_rx) = std::sync::mpsc::channel();
 
     // Spawn sender and receiver tasks
-    let sender_handle = tokio::spawn(async move {
-        sender_task(sender_tx, receiver_rx, sender_remote_mr_tx, receiver_remote_mr_rx, receiver_is_ready_rx).await
+    let sender_handle = std::thread::spawn(move || {
+        sender_task(sender_tx, receiver_rx, sender_remote_mr_tx, receiver_remote_mr_rx, receiver_is_ready_rx)
     });
 
-    let receiver_handle = tokio::spawn(async move {
-        receiver_task(receiver_tx, sender_rx, receiver_remote_mr_tx, sender_remote_mr_rx, receiver_is_ready_tx).await
+    let receiver_handle = std::thread::spawn(move || {
+        receiver_task(receiver_tx, sender_rx, receiver_remote_mr_tx, sender_remote_mr_rx, receiver_is_ready_tx)
     });
 
     // Wait for both tasks to complete
-    let (sender_result, receiver_result) = tokio::try_join!(sender_handle, receiver_handle)?;
+    let sender_result = sender_handle.join().map_err(|_| "Sender thread panicked")?;
+    let receiver_result = receiver_handle.join().map_err(|_| "Receiver thread panicked")?;
 
     sender_result?;
     receiver_result?;
@@ -43,12 +43,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
-async fn sender_task(
-    endpoint_tx: tokio::sync::oneshot::Sender<ibverbs::QueuePairEndpoint>,
-    peer_rx: tokio::sync::oneshot::Receiver<ibverbs::QueuePairEndpoint>,
-    remote_mr_tx: tokio::sync::oneshot::Sender<ibverbs::RemoteMemorySlice>,
-    remote_mr_rx: tokio::sync::oneshot::Receiver<ibverbs::RemoteMemorySlice>,
-    receiver_is_ready_rx: tokio::sync::oneshot::Receiver<bool>,
+fn sender_task(
+    endpoint_tx: std::sync::mpsc::Sender<ibverbs::QueuePairEndpoint>,
+    peer_rx: std::sync::mpsc::Receiver<ibverbs::QueuePairEndpoint>,
+    remote_mr_tx: std::sync::mpsc::Sender<ibverbs::RemoteMemorySlice>,
+    remote_mr_rx: std::sync::mpsc::Receiver<ibverbs::RemoteMemorySlice>,
+    receiver_is_ready_rx: std::sync::mpsc::Receiver<bool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Open RDMA device - assume EFA compatibility
     let ctx = match ibverbs::devices()
@@ -92,15 +92,15 @@ async fn sender_task(
 
     // Exchange endpoints and memory regions
     endpoint_tx.send(my_endpoint).map_err(|_| "Failed to send endpoint")?;
-    let peer_endpoint = peer_rx.await.map_err(|_| "Failed to receive peer endpoint")?;
-    let remote_mr = remote_mr_rx.await.unwrap();
+    let peer_endpoint = peer_rx.recv().map_err(|_| "Failed to receive peer endpoint")?;
+    let remote_mr = remote_mr_rx.recv().unwrap();
     remote_mr_tx.send(local_mr.remote()).unwrap();
 
     // Move QP to RTR states and create remote AH
     let mut qp = qp_builder.handshake(peer_endpoint).unwrap();
 
     // Wait for receiver to be ready
-    let receiver_is_ready = receiver_is_ready_rx.await.unwrap();
+    let receiver_is_ready = receiver_is_ready_rx.recv().unwrap();
     if !receiver_is_ready {
         return Err("Receiver is not ready".into());
     }
@@ -127,12 +127,12 @@ async fn sender_task(
     }
 }
 
-async fn receiver_task(
-    endpoint_tx: tokio::sync::oneshot::Sender<ibverbs::QueuePairEndpoint>,
-    peer_rx: tokio::sync::oneshot::Receiver<ibverbs::QueuePairEndpoint>,
-    remote_mr_tx: tokio::sync::oneshot::Sender<ibverbs::RemoteMemorySlice>,
-    remote_mr_rx: tokio::sync::oneshot::Receiver<ibverbs::RemoteMemorySlice>,
-    receiver_is_ready_tx: tokio::sync::oneshot::Sender<bool>,
+fn receiver_task(
+    endpoint_tx: std::sync::mpsc::Sender<ibverbs::QueuePairEndpoint>,
+    peer_rx: std::sync::mpsc::Receiver<ibverbs::QueuePairEndpoint>,
+    remote_mr_tx: std::sync::mpsc::Sender<ibverbs::RemoteMemorySlice>,
+    remote_mr_rx: std::sync::mpsc::Receiver<ibverbs::RemoteMemorySlice>,
+    receiver_is_ready_tx: std::sync::mpsc::Sender<bool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Open RDMA device - assume EFA compatibility
     let ctx = match ibverbs::devices()
@@ -176,9 +176,9 @@ async fn receiver_task(
 
     // Exchange endpoints and memory regions
     endpoint_tx.send(my_endpoint).map_err(|_| "Failed to send endpoint")?;
-    let peer_endpoint = peer_rx.await.map_err(|_| "Failed to receive peer endpoint")?;
+    let peer_endpoint = peer_rx.recv().map_err(|_| "Failed to receive peer endpoint")?;
     remote_mr_tx.send(local_mr.remote()).unwrap();
-    let _remote_mr = remote_mr_rx.await.unwrap();
+    let _remote_mr = remote_mr_rx.recv().unwrap();
 
     // Move QP to RTR states and create remote AH
     let mut qp = qp_builder.handshake(peer_endpoint).unwrap();
@@ -195,7 +195,7 @@ async fn receiver_task(
     loop {
         let completed = cq.poll(&mut completions[..]).unwrap();
         if completed.is_empty() {
-            tokio::task::yield_now().await;
+            std::thread::sleep(std::time::Duration::from_millis(1));
             continue;
         }
         for wr in completed {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -421,6 +421,10 @@ impl Context {
         Ok(ctx)
     }
 
+    /// Returns true if EFA is enabled for this context.
+    pub fn is_efa_enabled(&self) -> bool {
+        self.inner.enable_efa
+    }
 
     /// Create a completion queue (CQ).
     ///
@@ -1140,6 +1144,7 @@ impl QueuePairBuilder {
     pub fn build(&self) -> io::Result<PreparedQueuePair> {
 
         let qp = if self.pd.ctx.enable_efa {
+            #[cfg(feature = "efa")] {
             // EFA uses extended API to create an SRD QP.
             let send_ops_flags = (
                 ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE.0 |
@@ -1177,6 +1182,10 @@ impl QueuePairBuilder {
             };
 
             unsafe { ffi::efadv_create_qp_ex(self.pd.ctx.ctx, &mut attr, &mut efa_attr as *mut _, std::mem::size_of::<ffi::efadv_qp_init_attr>() as u32) }
+            }
+            #[cfg(not(feature = "efa"))] {
+                panic!("EFA feature is not enabled but ctx.enable_efa is true");
+            }
         } else {
             // otherwise, use standard ibverbs API to create a regular QP.
             let mut attr = ffi::ibv_qp_init_attr {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -2453,16 +2453,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_efa_dynamic_loading() {
-        // Test that EFA loading works (or gracefully fails if library not available)
-        // This demonstrates that EFA library is loaded lazily at runtime
-        let result = ffi::test_efa_loading();
-        // The test passes regardless of whether EFA library is available
-        // The important thing is that it doesn't crash during compilation/linking
-        let _ = result;
-    }
-
-    #[test]
     fn gid_array_conversion() {
         let arr = [
             0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1162,7 +1162,7 @@ impl QueuePairBuilder {
                     pd: self.pd.clone(),
                     qp,
                     ah: ptr::null_mut(),
-                    remote_endpoint: Default::default(),
+                    remote_endpoint: None,
                     enable_efa: self.enable_efa,
                 },
                 gid_index: self.gid_index,
@@ -1263,7 +1263,7 @@ impl QueuePairBuilder {
                     pd: self.pd.clone(),
                     qp,
                     ah: ptr::null_mut(),
-                    remote_endpoint: Default::default(),
+                    remote_endpoint: None,
                     enable_efa: self.enable_efa,
                 },
                 gid_index: self.gid_index,
@@ -1460,7 +1460,7 @@ impl From<ffi::ibv_gid_entry> for GidEntry {
 /// An identifier for the network endpoint of a `QueuePair`.
 ///
 /// Internally, this contains the `QueuePair`'s `qp_num`, as well as the context's `lid` and `gid`.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct QueuePairEndpoint {
     /// the `QueuePair`'s `qp_num`
@@ -1496,48 +1496,6 @@ impl PreparedQueuePair {
         })
     }
 
-    /// Set up the `QueuePair` such that it is ready to exchange packets with a remote `QueuePair`.
-    ///
-    /// Internally, this uses `ibv_modify_qp` to mark the `QueuePair` as initialized
-    /// (`IBV_QPS_INIT`), ready to receive (`IBV_QPS_RTR`), and ready to send (`IBV_QPS_RTS`).
-    /// Further discussion of the protocol can be found on [RDMAmojo].
-    ///
-    /// If `enable_efa` is set to `true`, this will use EFA-specific handshake. Otherwise,
-    /// it uses the standard ibverbs handshake.
-    ///
-    /// If the endpoint contains a Gid, the routing will be global. This means:
-    /// ```text,ignore
-    /// ah_attr.is_global = 1;
-    /// ah_attr.grh.hop_limit = 0xff;
-    /// ```
-    ///
-    /// The handshake also sets the following parameters, which are currently not configurable:
-    ///
-    /// # Examples
-    ///
-    /// ```text,ignore
-    /// port_num = PORT_NUM;
-    /// pkey_index = 0;
-    /// sq_psn = 0;
-    ///
-    /// ah_attr.sl = 0;
-    /// ah_attr.src_path_bits = 0;
-    /// ```
-    ///
-    /// # Errors
-    ///
-    ///  - `EINVAL`: Invalid value provided in `attr` or in `attr_mask`.
-    ///  - `ENOMEM`: Not enough resources to complete this operation.
-    ///
-    /// [RDMAmojo]: http://www.rdmamojo.com/2014/01/18/connecting-queue-pairs/
-    pub fn handshake(self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
-        if self.enable_efa {
-            self.handshake_efa(remote)
-        } else {
-            self.handshake_regular(remote)
-        }
-    }
-
     /// Set up the `QueuePair` such that it is ready to exchange packets with a remote `QueuePair` using standard ibverbs.
     ///
     /// Internally, this uses `ibv_modify_qp` to mark the `QueuePair` as initialized
@@ -1562,15 +1520,21 @@ impl PreparedQueuePair {
     /// ah_attr.sl = 0;
     /// ah_attr.src_path_bits = 0;
     /// ```
-    ///
+    /// Note(EFA): EFA is a connectionless protocol, the handshake is simply modifying the QP 
+    /// state from INIT -> RTS. A successful handshake does NOT gurantee that the remote endpoint
+    /// has successfully completed its own handshake. As such, the sender usually needs to retry
+    /// the first write request, OR have some other mechanism with which to gurantee that the 
+    /// receiver has completed its handshake first.
+    /// 
     /// # Errors
     ///
     ///  - `EINVAL`: Invalid value provided in `attr` or in `attr_mask`.
     ///  - `ENOMEM`: Not enough resources to complete this operation.
     ///
     /// [RDMAmojo]: http://www.rdmamojo.com/2014/01/18/connecting-queue-pairs/
-    fn handshake_regular(self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
+    pub fn handshake(mut self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
         // init and associate with port
+        let qp_type = unsafe { (*self.qp.qp).qp_type };
         let mut attr = ffi::ibv_qp_attr {
             qp_state: ffi::ibv_qp_state::IBV_QPS_INIT,
             pkey_index: 0,
@@ -1580,44 +1544,54 @@ impl PreparedQueuePair {
         let mut mask = ffi::ibv_qp_attr_mask::IBV_QP_STATE
             | ffi::ibv_qp_attr_mask::IBV_QP_PKEY_INDEX
             | ffi::ibv_qp_attr_mask::IBV_QP_PORT;
-        if let Some(access) = self.access {
-            attr.qp_access_flags = access.0;
-            mask |= ffi::ibv_qp_attr_mask::IBV_QP_ACCESS_FLAGS;
+
+        if !self.enable_efa {
+            if let Some(access) = self.access {
+                attr.qp_access_flags = access.0;
+                mask |= ffi::ibv_qp_attr_mask::IBV_QP_ACCESS_FLAGS;
+            }
         }
+
+        if self.enable_efa {
+            attr.qkey = UD_QKEY;
+            mask |= ffi::ibv_qp_attr_mask::IBV_QP_QKEY;
+            attr.port_num = PORT_NUM;
+            mask |= ffi::ibv_qp_attr_mask::IBV_QP_PORT;
+        }
+
         let errno = unsafe { ffi::ibv_modify_qp(self.qp.qp, &mut attr as *mut _, mask.0 as i32) };
         if errno != 0 {
             return Err(io::Error::from_raw_os_error(errno));
         }
 
         // set ready to receive
+        let mut mask = ffi::ibv_qp_attr_mask::IBV_QP_STATE;
         let mut attr = ffi::ibv_qp_attr {
             qp_state: ffi::ibv_qp_state::IBV_QPS_RTR,
-            // TODO: this is only valid for RC and UC
-            dest_qp_num: remote.num,
-            // TODO: this is only valid for RC and UC
-            ah_attr: ffi::ibv_ah_attr {
-                dlid: remote.lid,
-                sl: self.service_level,
-                src_path_bits: 0,
-                port_num: PORT_NUM,
-                grh: Default::default(),
-                ..Default::default()
-            },
             ..Default::default()
         };
-        if let Some(gid) = remote.gid {
-            attr.ah_attr.is_global = 1;
-            attr.ah_attr.grh.dgid = gid.into();
-            attr.ah_attr.grh.hop_limit = 0xff;
-            attr.ah_attr.grh.sgid_index = self
-                .gid_index
-                .ok_or_else(|| io::Error::other("gid was set for remote but not local"))?
-                as u8;
-            attr.ah_attr.grh.traffic_class = self.traffic_class;
+
+        if qp_type == ffi::ibv_qp_type::IBV_QPT_RC || qp_type == ffi::ibv_qp_type::IBV_QPT_UC {
+            attr.dest_qp_num = remote.num;
+            attr.ah_attr.dlid = remote.lid;
+            attr.ah_attr.sl = self.service_level;
+            attr.ah_attr.src_path_bits = 0;
+            attr.ah_attr.port_num = PORT_NUM;
+            attr.ah_attr.grh = Default::default();
+            if let Some(gid) = remote.gid {
+                attr.ah_attr.is_global = 1;
+                attr.ah_attr.grh.dgid = gid.into();
+                attr.ah_attr.grh.hop_limit = 0xff;
+                attr.ah_attr.grh.sgid_index = self
+                    .gid_index
+                    .ok_or_else(|| io::Error::other("gid was set for remote but not local"))?
+                    as u8;
+                attr.ah_attr.grh.traffic_class = self.traffic_class;
+            }
+            mask |= ffi::ibv_qp_attr_mask::IBV_QP_DEST_QPN;
+            mask |= ffi::ibv_qp_attr_mask::IBV_QP_AV;
         }
-        let mut mask = ffi::ibv_qp_attr_mask::IBV_QP_STATE
-            | ffi::ibv_qp_attr_mask::IBV_QP_AV
-            | ffi::ibv_qp_attr_mask::IBV_QP_DEST_QPN;
+        
         if let Some(max_dest_rd_atomic) = self.max_dest_rd_atomic {
             attr.max_dest_rd_atomic = max_dest_rd_atomic;
             mask |= ffi::ibv_qp_attr_mask::IBV_QP_MAX_DEST_RD_ATOMIC;
@@ -1667,102 +1641,34 @@ impl PreparedQueuePair {
             return Err(io::Error::from_raw_os_error(errno));
         }
 
-        Ok(self.qp)
-    }
-
-    /// Build a new QueuePair for EFA.
-    /// Modifies the QP state to INIT, RTR, and RTS. It also creates an AH for the remote endpoint,
-    /// allowing for RDMA operations to that endpoint.
-    ///
-    /// Note that since EFA is a connectionless protocol, the handshake is simply modifying the QP 
-    /// state from INIT -> RTS. A successful handshake does NOT gurantee that the remote endpoint
-    /// has successfully completed its own handshake. As such, the sender usually needs to retry
-    /// the first write request, OR have some other mechanism with which to gurantee that the 
-    /// receiver has completed its handshake first.
-    ///
-    /// # Errors
-    ///
-    ///  - `EINVAL`: Invalid value provided in `attr` or in `attr_mask`.
-    ///  - `ENOMEM`: Not enough resources to complete this operation.
-    pub fn handshake_efa(mut self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
-        let qp = self.qp.qp;
-        let mut attr = std::mem::MaybeUninit::<ffi::ibv_qp_attr>::uninit();
-        unsafe {
-            std::ptr::write_bytes(attr.as_mut_ptr(), 0, 1);
-            let attr_ptr = attr.as_mut_ptr();
-            (*attr_ptr).qp_state = ffi::ibv_qp_state::IBV_QPS_INIT;
-            (*attr_ptr).qkey = UD_QKEY;
-            (*attr_ptr).pkey_index = 0;
-            (*attr_ptr).port_num = PORT_NUM;
-        }
-
-        let mask = (ffi::ibv_qp_attr_mask::IBV_QP_STATE.0 |
-                   ffi::ibv_qp_attr_mask::IBV_QP_PKEY_INDEX.0 |
-                   ffi::ibv_qp_attr_mask::IBV_QP_PORT.0 |
-                   ffi::ibv_qp_attr_mask::IBV_QP_QKEY.0) as i32;
-
-        let errno = unsafe { ffi::ibv_modify_qp(qp, attr.as_mut_ptr(), mask) };
-        if errno != 0 {
-            return Err(io::Error::from_raw_os_error(errno));
-        }
-
-        // set RTR
-        unsafe {
-            std::ptr::write_bytes(attr.as_mut_ptr(), 0, 1);
-            (*attr.as_mut_ptr()).qp_state = ffi::ibv_qp_state::IBV_QPS_RTR;
-        }
-
-        let mask = ffi::ibv_qp_attr_mask::IBV_QP_STATE.0 as i32;
-
-        let errno = unsafe { ffi::ibv_modify_qp(qp, attr.as_mut_ptr(), mask) };
-        if errno != 0 {
-            return Err(io::Error::from_raw_os_error(errno));
-        }
-
-        // set RTS
-        unsafe {
-            std::ptr::write_bytes(attr.as_mut_ptr(), 0, 1);
-            let attr_ptr = attr.as_mut_ptr();
-            (*attr_ptr).qp_state = ffi::ibv_qp_state::IBV_QPS_RTS;
-            (*attr_ptr).rnr_retry = self.rnr_retry.unwrap_or(3);
-        }
-
-        let mask = (ffi::ibv_qp_attr_mask::IBV_QP_STATE.0 |
-                   ffi::ibv_qp_attr_mask::IBV_QP_SQ_PSN.0 |
-                   ffi::ibv_qp_attr_mask::IBV_QP_RNR_RETRY.0) as i32;
-
-        let errno = unsafe { ffi::ibv_modify_qp(qp, attr.as_mut_ptr(), mask) };
-        if errno != 0 {
-            return Err(io::Error::from_raw_os_error(errno));
-        }
-
-        // Ensure we have a valid AH for EFA operations
-        let ah = if self.qp.ah.is_null() {
-            let mut ah_attr = ffi::ibv_ah_attr {
-                dlid: remote.lid,
-                sl: 0,
-                src_path_bits: 0,
-                port_num: PORT_NUM,
-                is_global: 1,
-                static_rate: 0,
-                grh: ffi::ibv_global_route {
-                    dgid: remote.gid.unwrap().into(),
+        if self.enable_efa {
+            // EFA QP requires an AH to be created for the remote endpoint.
+            let ah = if self.qp.ah.is_null() {
+                let mut ah_attr = ffi::ibv_ah_attr {
+                    dlid: remote.lid,
+                    sl: 0,
+                    src_path_bits: 0,
+                    port_num: PORT_NUM,
+                    is_global: 1,
+                    static_rate: 0,
+                    grh: ffi::ibv_global_route {
+                        dgid: remote.gid.unwrap().into(),
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
+                };
+    
+                let test_ah = unsafe { ffi::ibv_create_ah(self.qp.pd.pd, &mut ah_attr as *mut _) };
+                if test_ah.is_null() {
+                    return Err(io::Error::last_os_error());
+                }
+                test_ah
+            } else {
+                self.qp.ah
             };
-
-            let test_ah = unsafe { ffi::ibv_create_ah(self.qp.pd.pd, &mut ah_attr as *mut _) };
-            if test_ah.is_null() {
-                return Err(io::Error::last_os_error());
-            }
-            test_ah
-        } else {
-            self.qp.ah
-        };
-
-        self.qp.ah = ah;
-        self.qp.remote_endpoint = remote;
+            self.qp.ah = ah;
+            self.qp.remote_endpoint = Some(remote);
+        }
 
         Ok(self.qp)
     }
@@ -2125,7 +2031,7 @@ pub struct QueuePair {
     pd: Arc<ProtectionDomainInner>,
     qp: *mut ffi::ibv_qp,
     ah: *mut ffi::ibv_ah,
-    remote_endpoint: QueuePairEndpoint,
+    remote_endpoint: Option<QueuePairEndpoint>,
     enable_efa: bool,
 }
 
@@ -2288,7 +2194,7 @@ impl QueuePair {
     ) -> io::Result<()> {
         if self.enable_efa {
             // This is an EFA QP, use EFA write
-            self.post_write_efa(local, remote, self.remote_endpoint, wr_id, imm_data)
+            self.post_write_efa(local, remote, self.remote_endpoint.unwrap(), wr_id, imm_data)
         } else {
             // This is a regular QP, use standard write
             self.post_write_regular(local, remote, wr_id, imm_data)

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -264,7 +264,16 @@ impl<'devlist> Device<'devlist> {
     ///  - `EMFILE`: Too many files are opened by this process (from `ibv_query_gid`).
     ///  - Other: the device is not in `ACTIVE` or `ARMED` state.
     pub fn open(&self) -> io::Result<Context> {
-        Context::with_device(*self.0)
+        Context::with_device(*self.0, false)
+    }
+
+    /// Opens an RDMA device and creates a context for further use with EFA support enabled.
+    ///
+    /// # Errors
+    ///
+    /// Same as `open()`.
+    pub fn open_with_efa(&self) -> io::Result<Context> {
+        Context::with_device(*self.0, true)
     }
 
     /// Returns a string of the name, which is associated with this RDMA device.
@@ -339,6 +348,7 @@ impl<'devlist> Device<'devlist> {
 
 struct ContextInner {
     ctx: *mut ffi::ibv_context,
+    enable_efa: bool,
 }
 
 impl ContextInner {
@@ -396,20 +406,21 @@ pub struct Context {
 
 impl Context {
     /// Opens a context for the given device, and queries its port and gid.
-    fn with_device(dev: *mut ffi::ibv_device) -> io::Result<Context> {
+    fn with_device(dev: *mut ffi::ibv_device, enable_efa: bool) -> io::Result<Context> {
         assert!(!dev.is_null());
 
         let ctx = unsafe { ffi::ibv_open_device(dev) };
         if ctx.is_null() {
             return Err(io::Error::other("failed to open device"));
         }
-        let inner = Arc::new(ContextInner { ctx });
+        let inner = Arc::new(ContextInner { ctx, enable_efa });
 
         let ctx = Context { inner };
         // checks that the port is active/armed.
         ctx.inner.query_port()?;
         Ok(ctx)
     }
+
 
     /// Create a completion queue (CQ).
     ///
@@ -743,8 +754,6 @@ pub struct QueuePairBuilder {
     rq_psn: Option<u32>,
     /// service level (0-15). Higher value means higher priority.
     service_level: u8,
-    /// Enable EFA (Elastic Fabric Adapter) support.
-    enable_efa: bool,
 }
 
 impl QueuePairBuilder {
@@ -808,7 +817,6 @@ impl QueuePairBuilder {
                 || qp_type == ffi::ibv_qp_type::IBV_QPT_UC)
                 .then_some(0),
             service_level: 0,
-            enable_efa: false,
         }
     }
 
@@ -848,15 +856,6 @@ impl QueuePairBuilder {
     /// Defaults to 0.
     pub fn set_service_level(&mut self, service_level: u8) -> &mut Self {
         self.service_level = service_level;
-        self
-    }
-
-    /// Enable or disable EFA (Elastic Fabric Adapter) support for the new `QueuePair`.
-    ///
-    /// When enabled, the `build()` method will use EFA-specific QP creation and handshake methods.
-    /// Defaults to false.
-    pub fn enable_efa(&mut self, enable_efa: bool) -> &mut Self {
-        self.enable_efa = enable_efa;
         self
     }
 
@@ -1140,7 +1139,7 @@ impl QueuePairBuilder {
     ///  - `EPERM`: Not enough permissions to create a QP with this Transport Service Type.
     pub fn build(&self) -> io::Result<PreparedQueuePair> {
 
-        let qp = if self.enable_efa {
+        let qp = if self.pd.ctx.enable_efa {
             // EFA uses extended API to create an SRD QP.
             let send_ops_flags = (ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE.0 |
                 ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM.0 |
@@ -1203,7 +1202,6 @@ impl QueuePairBuilder {
                     qp,
                     ah: ptr::null_mut(),
                     remote_endpoint: None,
-                    enable_efa: self.enable_efa,
                 },
                 gid_index: self.gid_index,
                 traffic_class: self.traffic_class,
@@ -1217,7 +1215,6 @@ impl QueuePairBuilder {
                 path_mtu: self.path_mtu,
                 rq_psn: self.rq_psn,
                 service_level: self.service_level,
-                enable_efa: self.enable_efa,
             })
         }
     }
@@ -1275,8 +1272,6 @@ pub struct PreparedQueuePair {
     rq_psn: Option<u32>,
     /// service level (0-15). Higher value means higher priority.
     service_level: u8,
-    /// Enable EFA (Elastic Fabric Adapter) support.
-    enable_efa: bool,
 }
 
 /// A Global identifier for ibv.
@@ -1484,14 +1479,14 @@ impl PreparedQueuePair {
             | ffi::ibv_qp_attr_mask::IBV_QP_PKEY_INDEX
             | ffi::ibv_qp_attr_mask::IBV_QP_PORT;
 
-        if !self.enable_efa {
+        if !self.qp.pd.ctx.enable_efa {
             if let Some(access) = self.access {
                 attr.qp_access_flags = access.0;
                 mask |= ffi::ibv_qp_attr_mask::IBV_QP_ACCESS_FLAGS;
             }
         }
 
-        if self.enable_efa {
+        if self.qp.pd.ctx.enable_efa {
             attr.qkey = UD_QKEY;
             mask |= ffi::ibv_qp_attr_mask::IBV_QP_QKEY;
             attr.port_num = PORT_NUM;
@@ -1580,7 +1575,7 @@ impl PreparedQueuePair {
             return Err(io::Error::from_raw_os_error(errno));
         }
 
-        if self.enable_efa {
+        if self.qp.pd.ctx.enable_efa {
             // EFA QP requires an AH to be created for the remote endpoint.
             let ah = if self.qp.ah.is_null() {
                 let mut ah_attr = ffi::ibv_ah_attr {
@@ -1884,7 +1879,11 @@ impl ProtectionDomain {
     ///  - `ENOMEM`: Not enough resources (either in operating system or in RDMA device) to
     ///    complete this operation.
     pub fn allocate(&self, n: usize) -> io::Result<MemoryRegion<Vec<u8>>> {
-        let access_flags = DEFAULT_ACCESS_FLAGS;
+        let access_flags = if self.inner.ctx.enable_efa {
+            EFA_DEFAULT_ACCESS_FLAGS
+        } else {
+            DEFAULT_ACCESS_FLAGS
+        };
         self.allocate_with_permissions(n, access_flags)
     }
 
@@ -1921,7 +1920,12 @@ impl ProtectionDomain {
         &self,
         data: T,
     ) -> io::Result<MemoryRegion<T>> {
-        self.register_with_permissions(data, DEFAULT_ACCESS_FLAGS)
+        let access_flags = if self.inner.ctx.enable_efa {
+            EFA_DEFAULT_ACCESS_FLAGS
+        } else {
+            DEFAULT_ACCESS_FLAGS
+        };
+        self.register_with_permissions(data, access_flags)
     }
 
     /// Registers an already allocated DMA-BUF memory region (MR) associated with this `ProtectionDomain`.
@@ -1971,7 +1975,6 @@ pub struct QueuePair {
     qp: *mut ffi::ibv_qp,
     ah: *mut ffi::ibv_ah,
     remote_endpoint: Option<QueuePairEndpoint>,
-    enable_efa: bool,
 }
 
 unsafe impl Send for QueuePair {}
@@ -2131,7 +2134,7 @@ impl QueuePair {
         wr_id: u64,
         imm_data: Option<u32>,
     ) -> io::Result<()> {
-        if self.enable_efa {
+        if self.pd.ctx.enable_efa {
             // This is an EFA QP, use EFA write
             self.post_write_efa(local, remote, self.remote_endpoint.unwrap(), wr_id, imm_data)
         } else {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1181,7 +1181,15 @@ impl QueuePairBuilder {
                 ..Default::default()
             };
 
-            unsafe { ffi::efadv_create_qp_ex(self.pd.ctx.ctx, &mut attr, &mut efa_attr as *mut _, std::mem::size_of::<ffi::efadv_qp_init_attr>() as u32) }
+            let qp = match ffi::get_efa_functions() {
+                Ok(efa_funcs) => unsafe {
+                    (efa_funcs.efadv_create_qp_ex)(self.pd.ctx.ctx, &mut attr, &mut efa_attr as *mut _, std::mem::size_of::<ffi::efadv_qp_init_attr>() as u32)
+                },
+                Err(e) => {
+                    return Err(io::Error::other(format!("Failed to load EFA functions: {}", e)));
+                }
+            };
+            qp
             }
             #[cfg(not(feature = "efa"))] {
                 panic!("EFA feature is not enabled but ctx.enable_efa is true");
@@ -2018,6 +2026,45 @@ impl QueuePair {
     /// [1]: http://www.rdmamojo.com/2013/01/26/ibv_post_send/
     #[inline]
     pub unsafe fn post_send(&mut self, local: &[LocalMemorySlice], wr_id: u64) -> io::Result<()> {
+        if self.pd.ctx.enable_efa {
+            self.post_send_efa(local, wr_id)
+        } else {
+            self.post_send_regular(local, wr_id)
+        }
+    }
+
+    #[inline]
+    /// Remote RDMA send using EFA.
+    fn post_send_efa(&mut self, local: &[LocalMemorySlice], wr_id: u64) -> io::Result<()> {
+        let qp_ex_ptr = unsafe { ffi::ibv_qp_to_qp_ex(self.qp) };
+        if qp_ex_ptr.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let qp_ex = unsafe { &mut *qp_ex_ptr };
+
+        let errno = unsafe {
+            qp_ex.wr_start.unwrap()(qp_ex);
+            qp_ex.wr_id = wr_id;
+            qp_ex.comp_mask = 0;
+            qp_ex.wr_flags = ffi::ibv_send_flags::IBV_SEND_SIGNALED.0;
+            qp_ex.wr_send.unwrap()(qp_ex);
+            qp_ex.wr_set_sge_list.unwrap()(qp_ex, local.len(), local.as_ptr() as *mut ffi::ibv_sge);
+            qp_ex.wr_set_ud_addr.unwrap()(qp_ex, self.ah, self.remote_endpoint.unwrap().num, UD_QKEY);
+            qp_ex.wr_complete.unwrap()(qp_ex)
+        };
+        if errno != 0 {
+            Err(io::Error::from_raw_os_error(errno))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    /// Remote RDMA write using standard ibverbs.
+    /// immediate data can be used to signal the completion of the write operation
+    /// the other side uses post_recv on a dummy buffer and get the imm data from the work completion
+    fn post_send_regular(&mut self, local: &[LocalMemorySlice], wr_id: u64) -> io::Result<()> {
         let mut wr = ffi::ibv_send_wr {
             wr_id,
             next: ptr::null::<ffi::ibv_send_wr>() as *mut _,
@@ -2195,8 +2242,6 @@ impl QueuePair {
                 qp_ex.wr_rdma_write.unwrap()(qp_ex, remote_mr.rkey, remote_mr.addr);
             };
             qp_ex.wr_set_sge_list.unwrap()(qp_ex, local.len(), local.as_ptr() as *mut ffi::ibv_sge);
-            // TODO(Eric): Consider creating and caching AH for each remote_endpoint...
-            // This way a single QP can be shared for multiple remote endpoints.
             qp_ex.wr_set_ud_addr.unwrap()(qp_ex, self.ah, self.remote_endpoint.unwrap().num, UD_QKEY);
             qp_ex.wr_complete.unwrap()(qp_ex)
         };
@@ -2406,6 +2451,16 @@ mod test_serde {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_efa_dynamic_loading() {
+        // Test that EFA loading works (or gracefully fails if library not available)
+        // This demonstrates that EFA library is loaded lazily at runtime
+        let result = ffi::test_efa_loading();
+        // The test passes regardless of whether EFA library is available
+        // The important thing is that it doesn't crash during compilation/linking
+        let _ = result;
+    }
 
     #[test]
     fn gid_array_conversion() {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -743,6 +743,8 @@ pub struct QueuePairBuilder {
     rq_psn: Option<u32>,
     /// service level (0-15). Higher value means higher priority.
     service_level: u8,
+    /// Enable EFA (Elastic Fabric Adapter) support.
+    enable_efa: bool,
 }
 
 impl QueuePairBuilder {
@@ -806,6 +808,7 @@ impl QueuePairBuilder {
                 || qp_type == ffi::ibv_qp_type::IBV_QPT_UC)
                 .then_some(0),
             service_level: 0,
+            enable_efa: false,
         }
     }
 
@@ -845,6 +848,15 @@ impl QueuePairBuilder {
     /// Defaults to 0.
     pub fn set_service_level(&mut self, service_level: u8) -> &mut Self {
         self.service_level = service_level;
+        self
+    }
+
+    /// Enable or disable EFA (Elastic Fabric Adapter) support for the new `QueuePair`.
+    ///
+    /// When enabled, the `build()` method will use EFA-specific QP creation and handshake methods.
+    /// Defaults to false.
+    pub fn enable_efa(&mut self, enable_efa: bool) -> &mut Self {
+        self.enable_efa = enable_efa;
         self
     }
 
@@ -1109,7 +1121,7 @@ impl QueuePairBuilder {
         self
     }
 
-    /// Create a new `QueuePair` from this builder template.
+    /// Create a new `QueuePair` from this builder template using standard ibverbs API.
     ///
     /// The returned `QueuePair` is associated with the builder's `ProtectionDomain`.
     ///
@@ -1123,7 +1135,7 @@ impl QueuePairBuilder {
     ///  - `ENOMEM`: Not enough resources to complete this operation.
     ///  - `ENOSYS`: QP with this Transport Service Type isn't supported by this RDMA device.
     ///  - `EPERM`: Not enough permissions to create a QP with this Transport Service Type.
-    pub fn build(&self) -> io::Result<PreparedQueuePair> {
+    fn build_regular(&self) -> io::Result<PreparedQueuePair> {
         let mut attr = ffi::ibv_qp_init_attr {
             qp_context: unsafe { ptr::null::<c_void>().offset(self.ctx) } as *mut _,
             send_cq: self.send.cq as *const _ as *mut _,
@@ -1150,6 +1162,8 @@ impl QueuePairBuilder {
                     pd: self.pd.clone(),
                     qp,
                     ah: ptr::null_mut(),
+                    remote_endpoint: Default::default(),
+                    enable_efa: self.enable_efa,
                 },
                 gid_index: self.gid_index,
                 traffic_class: self.traffic_class,
@@ -1163,7 +1177,33 @@ impl QueuePairBuilder {
                 path_mtu: self.path_mtu,
                 rq_psn: self.rq_psn,
                 service_level: self.service_level,
+                enable_efa: self.enable_efa,
             })
+        }
+    }
+
+    /// Create a new `QueuePair` from this builder template.
+    ///
+    /// The returned `QueuePair` is associated with the builder's `ProtectionDomain`.
+    ///
+    /// This method will fail if asked to create QP of a type other than `IBV_QPT_RC` or
+    /// `IBV_QPT_UD` associated with an SRQ.
+    ///
+    /// If `enable_efa` is set to `true`, this will use EFA-specific QP creation. Otherwise,
+    /// it uses the standard ibverbs API.
+    ///
+    /// # Errors
+    ///
+    ///  - `EINVAL`: Invalid `ProtectionDomain`, sending or receiving `Context`, or invalid value
+    ///    provided in `max_send_wr`, `max_recv_wr`, or in `max_inline_data`.
+    ///  - `ENOMEM`: Not enough resources to complete this operation.
+    ///  - `ENOSYS`: QP with this Transport Service Type isn't supported by this RDMA device.
+    ///  - `EPERM`: Not enough permissions to create a QP with this Transport Service Type.
+    pub fn build(&self) -> io::Result<PreparedQueuePair> {
+        if self.enable_efa {
+            self.build_efa()
+        } else {
+            self.build_regular()
         }
     }
 
@@ -1223,6 +1263,8 @@ impl QueuePairBuilder {
                     pd: self.pd.clone(),
                     qp,
                     ah: ptr::null_mut(),
+                    remote_endpoint: Default::default(),
+                    enable_efa: self.enable_efa,
                 },
                 gid_index: self.gid_index,
                 traffic_class: self.traffic_class,
@@ -1236,6 +1278,7 @@ impl QueuePairBuilder {
                 path_mtu: self.path_mtu,
                 rq_psn: self.rq_psn,
                 service_level: self.service_level,
+                enable_efa: self.enable_efa,
             })
         }
     }
@@ -1293,6 +1336,8 @@ pub struct PreparedQueuePair {
     rq_psn: Option<u32>,
     /// service level (0-15). Higher value means higher priority.
     service_level: u8,
+    /// Enable EFA (Elastic Fabric Adapter) support.
+    enable_efa: bool,
 }
 
 /// A Global identifier for ibv.
@@ -1457,6 +1502,9 @@ impl PreparedQueuePair {
     /// (`IBV_QPS_INIT`), ready to receive (`IBV_QPS_RTR`), and ready to send (`IBV_QPS_RTS`).
     /// Further discussion of the protocol can be found on [RDMAmojo].
     ///
+    /// If `enable_efa` is set to `true`, this will use EFA-specific handshake. Otherwise,
+    /// it uses the standard ibverbs handshake.
+    ///
     /// If the endpoint contains a Gid, the routing will be global. This means:
     /// ```text,ignore
     /// ah_attr.is_global = 1;
@@ -1483,6 +1531,45 @@ impl PreparedQueuePair {
     ///
     /// [RDMAmojo]: http://www.rdmamojo.com/2014/01/18/connecting-queue-pairs/
     pub fn handshake(self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
+        if self.enable_efa {
+            self.handshake_efa(remote)
+        } else {
+            self.handshake_regular(remote)
+        }
+    }
+
+    /// Set up the `QueuePair` such that it is ready to exchange packets with a remote `QueuePair` using standard ibverbs.
+    ///
+    /// Internally, this uses `ibv_modify_qp` to mark the `QueuePair` as initialized
+    /// (`IBV_QPS_INIT`), ready to receive (`IBV_QPS_RTR`), and ready to send (`IBV_QPS_RTS`).
+    /// Further discussion of the protocol can be found on [RDMAmojo].
+    ///
+    /// If the endpoint contains a Gid, the routing will be global. This means:
+    /// ```text,ignore
+    /// ah_attr.is_global = 1;
+    /// ah_attr.grh.hop_limit = 0xff;
+    /// ```
+    ///
+    /// The handshake also sets the following parameters, which are currently not configurable:
+    ///
+    /// # Examples
+    ///
+    /// ```text,ignore
+    /// port_num = PORT_NUM;
+    /// pkey_index = 0;
+    /// sq_psn = 0;
+    ///
+    /// ah_attr.sl = 0;
+    /// ah_attr.src_path_bits = 0;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    ///  - `EINVAL`: Invalid value provided in `attr` or in `attr_mask`.
+    ///  - `ENOMEM`: Not enough resources to complete this operation.
+    ///
+    /// [RDMAmojo]: http://www.rdmamojo.com/2014/01/18/connecting-queue-pairs/
+    fn handshake_regular(self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
         // init and associate with port
         let mut attr = ffi::ibv_qp_attr {
             qp_state: ffi::ibv_qp_state::IBV_QPS_INIT,
@@ -1675,6 +1762,7 @@ impl PreparedQueuePair {
         };
 
         self.qp.ah = ah;
+        self.qp.remote_endpoint = remote;
 
         Ok(self.qp)
     }
@@ -2037,6 +2125,8 @@ pub struct QueuePair {
     pd: Arc<ProtectionDomainInner>,
     qp: *mut ffi::ibv_qp,
     ah: *mut ffi::ibv_ah,
+    remote_endpoint: QueuePairEndpoint,
+    enable_efa: bool,
 }
 
 unsafe impl Send for QueuePair {}
@@ -2186,7 +2276,30 @@ impl QueuePair {
     /// Remote RDMA write.
     /// immediate data can be used to signal the completion of the write operation
     /// the other side uses post_recv on a dummy buffer and get the imm data from the work completion
+    ///
+    /// If this QueuePair was created with EFA support, this will use EFA-specific write operations.
+    /// Otherwise, it uses standard ibverbs RDMA write operations.
     pub fn post_write(
+        &mut self,
+        local: &[LocalMemorySlice],
+        remote: RemoteMemorySlice,
+        wr_id: u64,
+        imm_data: Option<u32>,
+    ) -> io::Result<()> {
+        if self.enable_efa {
+            // This is an EFA QP, use EFA write
+            self.post_write_efa(local, remote, self.remote_endpoint, wr_id, imm_data)
+        } else {
+            // This is a regular QP, use standard write
+            self.post_write_regular(local, remote, wr_id, imm_data)
+        }
+    }
+
+    #[inline]
+    /// Remote RDMA write using standard ibverbs.
+    /// immediate data can be used to signal the completion of the write operation
+    /// the other side uses post_recv on a dummy buffer and get the imm data from the work completion
+    fn post_write_regular(
         &mut self,
         local: &[LocalMemorySlice],
         remote: RemoteMemorySlice,
@@ -2244,6 +2357,45 @@ impl QueuePair {
     /// Get raw QP pointer (for testing/debugging purposes only).
     pub fn raw_qp_ptr(&self) -> *mut ffi::ibv_qp {
         self.qp
+    }
+
+    /// Remote RDMA read with EFA.
+    /// Upgrades QP to QP_EX
+    /// Note: EFA may not support immediate data with reads
+    pub fn post_read_efa(
+        &mut self,
+        local: &[LocalMemorySlice],
+        remote: RemoteMemorySlice,
+        remote_endpoint: QueuePairEndpoint,
+        wr_id: u64,
+        _imm_data: Option<u32>,
+    ) -> io::Result<()> {
+
+        let qp_ex = unsafe { ffi::ibv_qp_to_qp_ex(self.qp) };
+
+        unsafe {
+            (*qp_ex).wr_start.unwrap()(qp_ex);
+            (*qp_ex).wr_id = wr_id;
+            // set comp_mask to 0
+            (*qp_ex).comp_mask = 0;
+            // set wr_flags = IBV_SEND_SIGNALED
+            (*qp_ex).wr_flags = ffi::ibv_send_flags::IBV_SEND_SIGNALED.0;
+
+            // Set RDMA read parameters first (following write pattern)
+            (*qp_ex).wr_rdma_read.unwrap()(qp_ex, remote.rkey, remote.addr);
+
+            // set sge_list with num_Sge and sg_list
+            (*qp_ex).wr_set_sge_list.unwrap()(qp_ex, local.len(), local.as_ptr() as *mut ffi::ibv_sge);
+            // set ud_addr as remote->ah, remote_qpn, qkey
+            (*qp_ex).wr_set_ud_addr.unwrap()(qp_ex, self.ah, remote_endpoint.num, UD_QKEY);
+        };
+
+        let errno = unsafe {(*qp_ex).wr_complete.unwrap()(qp_ex)};
+        if errno != 0 {
+            Err(io::Error::from_raw_os_error(errno))
+        } else {
+            Ok(())
+        }
     }
 
     #[inline]

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1141,29 +1141,33 @@ impl QueuePairBuilder {
 
         let qp = if self.pd.ctx.enable_efa {
             // EFA uses extended API to create an SRD QP.
-            let send_ops_flags = (ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE.0 |
+            let send_ops_flags = (
+                ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE.0 |
                 ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM.0 |
                 ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_READ.0 |
                 ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND.0 |
-                ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND_WITH_IMM.0) as u32;
+                ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND_WITH_IMM.0
+            ) as u32;
             let mut attr = ffi::ibv_qp_init_attr_ex {
-            qp_context: self.pd.ctx.ctx as *mut _,
-            send_cq: self.send.cq as *const _ as *mut _,
-            recv_cq: self.recv.cq as *const _ as *mut _,
-            cap: ffi::ibv_qp_cap {
-            max_send_wr: self.max_send_wr,
-            max_recv_wr: self.max_recv_wr,
-            max_send_sge: self.max_send_sge,
-            max_recv_sge: self.max_recv_sge,
-            max_inline_data: self.max_inline_data,
-            },
-            qp_type: self.qp_type,
-            sq_sig_all: 1,
-            // attr ex specific
-            comp_mask: (ffi::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_PD | ffi::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_SEND_OPS_FLAGS).0,
-            pd: self.pd.pd,
-            send_ops_flags: send_ops_flags as u64,
-            ..Default::default()
+                qp_context: self.pd.ctx.ctx as *mut _,
+                send_cq: self.send.cq as *const _ as *mut _,
+                recv_cq: self.recv.cq as *const _ as *mut _,
+                cap: ffi::ibv_qp_cap {
+                    max_send_wr: self.max_send_wr,
+                    max_recv_wr: self.max_recv_wr,
+                    max_send_sge: self.max_send_sge,
+                    max_recv_sge: self.max_recv_sge,
+                    max_inline_data: self.max_inline_data,
+                },
+                qp_type: self.qp_type,
+                sq_sig_all: 1,
+                comp_mask: (
+                    ffi::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_PD |
+                    ffi::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_SEND_OPS_FLAGS
+                ).0,
+                pd: self.pd.pd,
+                send_ops_flags: send_ops_flags as u64,
+                ..Default::default()
             };
 
             let mut efa_attr = ffi::efadv_qp_init_attr {
@@ -1466,9 +1470,10 @@ impl PreparedQueuePair {
     ///  - `ENOMEM`: Not enough resources to complete this operation.
     ///
     /// [RDMAmojo]: http://www.rdmamojo.com/2014/01/18/connecting-queue-pairs/
-    pub fn handshake(mut self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
+    pub fn handshake(self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
         // init and associate with port
-        let qp_type = unsafe { (*self.qp.qp).qp_type };
+        let mut qp = self.qp;
+        let qp_type = unsafe { (*qp.qp).qp_type };
         let mut attr = ffi::ibv_qp_attr {
             qp_state: ffi::ibv_qp_state::IBV_QPS_INIT,
             pkey_index: 0,
@@ -1479,21 +1484,19 @@ impl PreparedQueuePair {
             | ffi::ibv_qp_attr_mask::IBV_QP_PKEY_INDEX
             | ffi::ibv_qp_attr_mask::IBV_QP_PORT;
 
-        if !self.qp.pd.ctx.enable_efa {
+        if qp.pd.ctx.enable_efa {
+            attr.qkey = UD_QKEY;
+            mask |= ffi::ibv_qp_attr_mask::IBV_QP_QKEY;
+            attr.port_num = PORT_NUM;
+            mask |= ffi::ibv_qp_attr_mask::IBV_QP_PORT;
+        } else {
             if let Some(access) = self.access {
                 attr.qp_access_flags = access.0;
                 mask |= ffi::ibv_qp_attr_mask::IBV_QP_ACCESS_FLAGS;
             }
         }
 
-        if self.qp.pd.ctx.enable_efa {
-            attr.qkey = UD_QKEY;
-            mask |= ffi::ibv_qp_attr_mask::IBV_QP_QKEY;
-            attr.port_num = PORT_NUM;
-            mask |= ffi::ibv_qp_attr_mask::IBV_QP_PORT;
-        }
-
-        let errno = unsafe { ffi::ibv_modify_qp(self.qp.qp, &mut attr as *mut _, mask.0 as i32) };
+        let errno = unsafe { ffi::ibv_modify_qp(qp.qp, &mut attr as *mut _, mask.0 as i32) };
         if errno != 0 {
             return Err(io::Error::from_raw_os_error(errno));
         }
@@ -1542,7 +1545,7 @@ impl PreparedQueuePair {
             attr.rq_psn = rq_psn;
             mask |= ffi::ibv_qp_attr_mask::IBV_QP_RQ_PSN;
         }
-        let errno = unsafe { ffi::ibv_modify_qp(self.qp.qp, &mut attr as *mut _, mask.0 as i32) };
+        let errno = unsafe { ffi::ibv_modify_qp(qp.qp, &mut attr as *mut _, mask.0 as i32) };
         if errno != 0 {
             return Err(io::Error::from_raw_os_error(errno));
         }
@@ -1570,41 +1573,34 @@ impl PreparedQueuePair {
             attr.max_rd_atomic = max_rd_atomic;
             mask |= ffi::ibv_qp_attr_mask::IBV_QP_MAX_QP_RD_ATOMIC;
         }
-        let errno = unsafe { ffi::ibv_modify_qp(self.qp.qp, &mut attr as *mut _, mask.0 as i32) };
+        let errno = unsafe { ffi::ibv_modify_qp(qp.qp, &mut attr as *mut _, mask.0 as i32) };
         if errno != 0 {
             return Err(io::Error::from_raw_os_error(errno));
         }
 
-        if self.qp.pd.ctx.enable_efa {
+        if qp.pd.ctx.enable_efa {
             // EFA QP requires an AH to be created for the remote endpoint.
-            let ah = if self.qp.ah.is_null() {
-                let mut ah_attr = ffi::ibv_ah_attr {
-                    dlid: remote.lid,
-                    sl: 0,
-                    src_path_bits: 0,
-                    port_num: PORT_NUM,
-                    is_global: 1,
-                    static_rate: 0,
-                    grh: ffi::ibv_global_route {
-                        dgid: remote.gid.unwrap().into(),
-                        ..Default::default()
-                    },
+            let mut ah_attr = ffi::ibv_ah_attr {
+                dlid: remote.lid,
+                sl: 0,
+                src_path_bits: 0,
+                port_num: PORT_NUM,
+                is_global: 1,
+                static_rate: 0,
+                grh: ffi::ibv_global_route {
+                    dgid: remote.gid.unwrap().into(),
                     ..Default::default()
-                };
-    
-                let test_ah = unsafe { ffi::ibv_create_ah(self.qp.pd.pd, &mut ah_attr as *mut _) };
-                if test_ah.is_null() {
-                    return Err(io::Error::last_os_error());
-                }
-                test_ah
-            } else {
-                self.qp.ah
+                },
+                ..Default::default()
             };
-            self.qp.ah = ah;
-            self.qp.remote_endpoint = Some(remote);
+            qp.ah = unsafe { ffi::ibv_create_ah(qp.pd.pd, &mut ah_attr as *mut _) };
+            if qp.ah.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            qp.remote_endpoint = Some(remote);
         }
 
-        Ok(self.qp)
+        Ok(qp)
     }
 }
 
@@ -2135,10 +2131,8 @@ impl QueuePair {
         imm_data: Option<u32>,
     ) -> io::Result<()> {
         if self.pd.ctx.enable_efa {
-            // This is an EFA QP, use EFA write
-            self.post_write_efa(local, remote, self.remote_endpoint.unwrap(), wr_id, imm_data)
+            self.post_write_efa(local, remote, wr_id, imm_data)
         } else {
-            // This is a regular QP, use standard write
             self.post_write_regular(local, remote, wr_id, imm_data)
         }
     }
@@ -2171,29 +2165,32 @@ impl QueuePair {
         &mut self,
         local: &[LocalMemorySlice],
         remote_mr: RemoteMemorySlice,
-        remote_endpoint: QueuePairEndpoint,
         wr_id: u64,
         imm_data: Option<u32>,
     ) -> io::Result<()> {
-        let qp_ex = unsafe { ffi::ibv_qp_to_qp_ex(self.qp) };
+        let qp_ex_ptr = unsafe { ffi::ibv_qp_to_qp_ex(self.qp) };
+        if qp_ex_ptr.is_null() {
+            return Err(io::Error::last_os_error());
+        }
 
-        unsafe {
-            (*qp_ex).wr_start.unwrap()(qp_ex);
-            (*qp_ex).wr_id = wr_id;
-            (*qp_ex).comp_mask = 0;
-            (*qp_ex).wr_flags = ffi::ibv_send_flags::IBV_SEND_SIGNALED.0;
+        let qp_ex = unsafe { &mut *qp_ex_ptr };
+
+        let errno = unsafe {
+            qp_ex.wr_start.unwrap()(qp_ex);
+            qp_ex.wr_id = wr_id;
+            qp_ex.comp_mask = 0;
+            qp_ex.wr_flags = ffi::ibv_send_flags::IBV_SEND_SIGNALED.0;
             if imm_data.is_some() {
-                (*qp_ex).wr_rdma_write_imm.unwrap()(qp_ex, remote_mr.rkey, remote_mr.addr, imm_data.unwrap().to_be());
+                qp_ex.wr_rdma_write_imm.unwrap()(qp_ex, remote_mr.rkey, remote_mr.addr, imm_data.unwrap().to_be());
             } else {
-                (*qp_ex).wr_rdma_write.unwrap()(qp_ex, remote_mr.rkey, remote_mr.addr);
+                qp_ex.wr_rdma_write.unwrap()(qp_ex, remote_mr.rkey, remote_mr.addr);
             };
-            (*qp_ex).wr_set_sge_list.unwrap()(qp_ex, local.len(), local.as_ptr() as *mut ffi::ibv_sge);
+            qp_ex.wr_set_sge_list.unwrap()(qp_ex, local.len(), local.as_ptr() as *mut ffi::ibv_sge);
             // TODO(Eric): Consider creating and caching AH for each remote_endpoint...
             // This way a single QP can be shared for multiple remote endpoints.
-            (*qp_ex).wr_set_ud_addr.unwrap()(qp_ex, self.ah, remote_endpoint.num, UD_QKEY);
+            qp_ex.wr_set_ud_addr.unwrap()(qp_ex, self.ah, self.remote_endpoint.unwrap().num, UD_QKEY);
+            qp_ex.wr_complete.unwrap()(qp_ex)
         };
-
-        let errno = unsafe {(*qp_ex).wr_complete.unwrap()(qp_ex)};
         if errno != 0 {
             Err(io::Error::from_raw_os_error(errno))
         } else {
@@ -2219,26 +2216,32 @@ impl QueuePair {
         _imm_data: Option<u32>,
     ) -> io::Result<()> {
 
-        let qp_ex = unsafe { ffi::ibv_qp_to_qp_ex(self.qp) };
+        let qp_ex_ptr = unsafe { ffi::ibv_qp_to_qp_ex(self.qp) };
 
-        unsafe {
-            (*qp_ex).wr_start.unwrap()(qp_ex);
-            (*qp_ex).wr_id = wr_id;
+        if qp_ex_ptr.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let qp_ex = unsafe { &mut *qp_ex_ptr };
+
+        let errno = unsafe {
+            qp_ex.wr_start.unwrap()(qp_ex);
+            qp_ex.wr_id = wr_id;
             // set comp_mask to 0
-            (*qp_ex).comp_mask = 0;
+            qp_ex.comp_mask = 0;
             // set wr_flags = IBV_SEND_SIGNALED
-            (*qp_ex).wr_flags = ffi::ibv_send_flags::IBV_SEND_SIGNALED.0;
+            qp_ex.wr_flags = ffi::ibv_send_flags::IBV_SEND_SIGNALED.0;
 
             // Set RDMA read parameters first (following write pattern)
-            (*qp_ex).wr_rdma_read.unwrap()(qp_ex, remote.rkey, remote.addr);
+            qp_ex.wr_rdma_read.unwrap()(qp_ex, remote.rkey, remote.addr);
 
             // set sge_list with num_Sge and sg_list
-            (*qp_ex).wr_set_sge_list.unwrap()(qp_ex, local.len(), local.as_ptr() as *mut ffi::ibv_sge);
+            qp_ex.wr_set_sge_list.unwrap()(qp_ex, local.len(), local.as_ptr() as *mut ffi::ibv_sge);
             // set ud_addr as remote->ah, remote_qpn, qkey
-            (*qp_ex).wr_set_ud_addr.unwrap()(qp_ex, self.ah, remote_endpoint.num, UD_QKEY);
-        };
+            qp_ex.wr_set_ud_addr.unwrap()(qp_ex, self.ah, remote_endpoint.num, UD_QKEY);
 
-        let errno = unsafe {(*qp_ex).wr_complete.unwrap()(qp_ex)};
+            qp_ex.wr_complete.unwrap()(qp_ex)
+        };
         if errno != 0 {
             Err(io::Error::from_raw_os_error(errno))
         } else {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1121,67 +1121,6 @@ impl QueuePairBuilder {
         self
     }
 
-    /// Create a new `QueuePair` from this builder template using standard ibverbs API.
-    ///
-    /// The returned `QueuePair` is associated with the builder's `ProtectionDomain`.
-    ///
-    /// This method will fail if asked to create QP of a type other than `IBV_QPT_RC` or
-    /// `IBV_QPT_UD` associated with an SRQ.
-    ///
-    /// # Errors
-    ///
-    ///  - `EINVAL`: Invalid `ProtectionDomain`, sending or receiving `Context`, or invalid value
-    ///    provided in `max_send_wr`, `max_recv_wr`, or in `max_inline_data`.
-    ///  - `ENOMEM`: Not enough resources to complete this operation.
-    ///  - `ENOSYS`: QP with this Transport Service Type isn't supported by this RDMA device.
-    ///  - `EPERM`: Not enough permissions to create a QP with this Transport Service Type.
-    fn build_regular(&self) -> io::Result<PreparedQueuePair> {
-        let mut attr = ffi::ibv_qp_init_attr {
-            qp_context: unsafe { ptr::null::<c_void>().offset(self.ctx) } as *mut _,
-            send_cq: self.send.cq as *const _ as *mut _,
-            recv_cq: self.recv.cq as *const _ as *mut _,
-            srq: ptr::null::<ffi::ibv_srq>() as *mut _,
-            cap: ffi::ibv_qp_cap {
-                max_send_wr: self.max_send_wr,
-                max_recv_wr: self.max_recv_wr,
-                max_send_sge: self.max_send_sge,
-                max_recv_sge: self.max_recv_sge,
-                max_inline_data: self.max_inline_data,
-            },
-            qp_type: self.qp_type,
-            sq_sig_all: 0,
-        };
-
-        let qp = unsafe { ffi::ibv_create_qp(self.pd.pd, &mut attr as *mut _) };
-        if qp.is_null() {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(PreparedQueuePair {
-                lid: self.port_attr.lid,
-                qp: QueuePair {
-                    pd: self.pd.clone(),
-                    qp,
-                    ah: ptr::null_mut(),
-                    remote_endpoint: None,
-                    enable_efa: self.enable_efa,
-                },
-                gid_index: self.gid_index,
-                traffic_class: self.traffic_class,
-                access: self.access,
-                timeout: self.timeout,
-                retry_count: self.retry_count,
-                rnr_retry: self.rnr_retry,
-                min_rnr_timer: self.min_rnr_timer,
-                max_rd_atomic: self.max_rd_atomic,
-                max_dest_rd_atomic: self.max_dest_rd_atomic,
-                path_mtu: self.path_mtu,
-                rq_psn: self.rq_psn,
-                service_level: self.service_level,
-                enable_efa: self.enable_efa,
-            })
-        }
-    }
-
     /// Create a new `QueuePair` from this builder template.
     ///
     /// The returned `QueuePair` is associated with the builder's `ProtectionDomain`.
@@ -1200,43 +1139,24 @@ impl QueuePairBuilder {
     ///  - `ENOSYS`: QP with this Transport Service Type isn't supported by this RDMA device.
     ///  - `EPERM`: Not enough permissions to create a QP with this Transport Service Type.
     pub fn build(&self) -> io::Result<PreparedQueuePair> {
-        if self.enable_efa {
-            self.build_efa()
-        } else {
-            self.build_regular()
-        }
-    }
 
-    /// Build a new `QueuePair` for that is EFA compatible, using the builder's attributes.
-    ///
-    /// The returned `QueuePair` is associated with the builder's `ProtectionDomain`.
-    ///
-    /// This uses extended API to create an SRD QP.
-    ///
-    /// # Errors
-    ///
-    ///  - `EINVAL`: Invalid `ProtectionDomain`, sending or receiving `Context`, or invalid value
-    ///    provided in `max_send_wr`, `max_recv_wr`, or in `max_inline_data`.
-    ///  - `ENOMEM`: Not enough resources to complete this operation.
-    ///  - `ENOSYS`: QP with this Transport Service Type isn't supported by this RDMA device.
-    ///  - `EPERM`: Not enough permissions to create a QP with this Transport Service Type.
-    pub fn build_efa(&self) -> io::Result<PreparedQueuePair> {
-        // Set send_ops_flags to enable RDMA operations (matching C++ example)
-        let send_ops_flags = (ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE.0 |
-                             ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM.0 |
-                             ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_READ.0 |
-                             ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND.0 |
-                             ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND_WITH_IMM.0) as u32;
-        let mut attr = ffi::ibv_qp_init_attr_ex {
+        let qp = if self.enable_efa {
+            // EFA uses extended API to create an SRD QP.
+            let send_ops_flags = (ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE.0 |
+                ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM.0 |
+                ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_READ.0 |
+                ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND.0 |
+                ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND_WITH_IMM.0) as u32;
+            let mut attr = ffi::ibv_qp_init_attr_ex {
             qp_context: self.pd.ctx.ctx as *mut _,
             send_cq: self.send.cq as *const _ as *mut _,
             recv_cq: self.recv.cq as *const _ as *mut _,
             cap: ffi::ibv_qp_cap {
-                max_send_wr: self.max_send_wr,
-                max_recv_wr: self.max_recv_wr,
-                max_send_sge: self.max_send_sge,
-                max_recv_sge: self.max_recv_sge,
-                max_inline_data: self.max_inline_data,
+            max_send_wr: self.max_send_wr,
+            max_recv_wr: self.max_recv_wr,
+            max_send_sge: self.max_send_sge,
+            max_recv_sge: self.max_recv_sge,
+            max_inline_data: self.max_inline_data,
             },
             qp_type: self.qp_type,
             sq_sig_all: 1,
@@ -1245,15 +1165,34 @@ impl QueuePairBuilder {
             pd: self.pd.pd,
             send_ops_flags: send_ops_flags as u64,
             ..Default::default()
-        };
+            };
 
-        let mut efa_attr = ffi::efadv_qp_init_attr {
-            driver_qp_type: ffi::EFADV_QP_DRIVER_TYPE_SRD as u32,
-            sl: 0 as u8,
-            ..Default::default()
-        };
+            let mut efa_attr = ffi::efadv_qp_init_attr {
+                driver_qp_type: ffi::EFADV_QP_DRIVER_TYPE_SRD as u32,
+                sl: 0 as u8,
+                ..Default::default()
+            };
 
-        let qp = unsafe { ffi::efadv_create_qp_ex(self.pd.ctx.ctx, &mut attr, &mut efa_attr as *mut _, std::mem::size_of::<ffi::efadv_qp_init_attr>() as u32) };
+            unsafe { ffi::efadv_create_qp_ex(self.pd.ctx.ctx, &mut attr, &mut efa_attr as *mut _, std::mem::size_of::<ffi::efadv_qp_init_attr>() as u32) }
+        } else {
+            // otherwise, use standard ibverbs API to create a regular QP.
+            let mut attr = ffi::ibv_qp_init_attr {
+                qp_context: unsafe { ptr::null::<c_void>().offset(self.ctx) } as *mut _,
+                send_cq: self.send.cq as *const _ as *mut _,
+                recv_cq: self.recv.cq as *const _ as *mut _,
+                srq: ptr::null::<ffi::ibv_srq>() as *mut _,
+                cap: ffi::ibv_qp_cap {
+                    max_send_wr: self.max_send_wr,
+                    max_recv_wr: self.max_recv_wr,
+                    max_send_sge: self.max_send_sge,
+                    max_recv_sge: self.max_recv_sge,
+                    max_inline_data: self.max_inline_data,
+                },
+                qp_type: self.qp_type,
+                sq_sig_all: 0,
+            };
+            unsafe { ffi::ibv_create_qp(self.pd.pd, &mut attr as *mut _) }
+        };
         if qp.is_null() {
             Err(io::Error::last_os_error())
         } else {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -76,6 +76,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 const PORT_NUM: u8 = 1;
+const UD_QKEY: u32 = 0x12345678;
 
 /// Direct access to low-level libverbs FFI.
 pub use ffi::ibv_gid_type;
@@ -98,6 +99,13 @@ pub const DEFAULT_ACCESS_FLAGS: ffi::ibv_access_flags = ffi::ibv_access_flags(
         | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_READ.0
         | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_ATOMIC.0
         | ffi::ibv_access_flags::IBV_ACCESS_RELAXED_ORDERING.0,
+);
+
+/// Default access flags compatible with EFA.
+pub const EFA_DEFAULT_ACCESS_FLAGS: ffi::ibv_access_flags = ffi::ibv_access_flags(
+    ffi::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0
+        | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0
+        | ffi::ibv_access_flags::IBV_ACCESS_REMOTE_READ.0
 );
 
 /// Get list of available RDMA devices.
@@ -517,13 +525,13 @@ impl Drop for CompletionQueueInner {
         let errno = unsafe { ffi::ibv_destroy_cq(self.cq) };
         if errno != 0 {
             let e = io::Error::from_raw_os_error(errno);
-            panic!("{e}");
+            panic!("Failed to destroy CQ: {e}");
         }
 
         let errno = unsafe { ffi::ibv_destroy_comp_channel(self.cc) };
         if errno != 0 {
             let e = io::Error::from_raw_os_error(errno);
-            panic!("{e}");
+            panic!("Failed to destroy completion channel: {e}");
         }
     }
 }
@@ -782,7 +790,8 @@ impl QueuePairBuilder {
             qp_type,
 
             access: (qp_type == ffi::ibv_qp_type::IBV_QPT_RC
-                || qp_type == ffi::ibv_qp_type::IBV_QPT_UC)
+                || qp_type == ffi::ibv_qp_type::IBV_QPT_UC
+                || qp_type == ffi::ibv_qp_type::IBV_QPT_DRIVER)
                 .then_some(ffi::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE),
             min_rnr_timer: (qp_type == ffi::ibv_qp_type::IBV_QPT_RC).then_some(16),
             retry_count: (qp_type == ffi::ibv_qp_type::IBV_QPT_RC).then_some(6),
@@ -802,12 +811,13 @@ impl QueuePairBuilder {
 
     /// Set the access flags for the new `QueuePair`.
     ///
-    /// Valid only for RC and UC QPs.
+    /// Valid only for RC, UC, and DRIVER QPs.
     ///
     /// Defaults to `IBV_ACCESS_LOCAL_WRITE`.
     pub fn set_access(&mut self, access: ffi::ibv_access_flags) -> &mut Self {
         if self.qp_type == ffi::ibv_qp_type::IBV_QPT_RC
             || self.qp_type == ffi::ibv_qp_type::IBV_QPT_UC
+            || self.qp_type == ffi::ibv_qp_type::IBV_QPT_DRIVER
         {
             self.access = Some(access);
         }
@@ -1139,6 +1149,80 @@ impl QueuePairBuilder {
                 qp: QueuePair {
                     pd: self.pd.clone(),
                     qp,
+                    ah: ptr::null_mut(),
+                },
+                gid_index: self.gid_index,
+                traffic_class: self.traffic_class,
+                access: self.access,
+                timeout: self.timeout,
+                retry_count: self.retry_count,
+                rnr_retry: self.rnr_retry,
+                min_rnr_timer: self.min_rnr_timer,
+                max_rd_atomic: self.max_rd_atomic,
+                max_dest_rd_atomic: self.max_dest_rd_atomic,
+                path_mtu: self.path_mtu,
+                rq_psn: self.rq_psn,
+                service_level: self.service_level,
+            })
+        }
+    }
+
+    /// Build a new `QueuePair` for that is EFA compatible, using the builder's attributes.
+    ///
+    /// The returned `QueuePair` is associated with the builder's `ProtectionDomain`.
+    ///
+    /// This uses extended API to create an SRD QP.
+    ///
+    /// # Errors
+    ///
+    ///  - `EINVAL`: Invalid `ProtectionDomain`, sending or receiving `Context`, or invalid value
+    ///    provided in `max_send_wr`, `max_recv_wr`, or in `max_inline_data`.
+    ///  - `ENOMEM`: Not enough resources to complete this operation.
+    ///  - `ENOSYS`: QP with this Transport Service Type isn't supported by this RDMA device.
+    ///  - `EPERM`: Not enough permissions to create a QP with this Transport Service Type.
+    pub fn build_efa(&self) -> io::Result<PreparedQueuePair> {
+        // Set send_ops_flags to enable RDMA operations (matching C++ example)
+        let send_ops_flags = (ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE.0 |
+                             ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM.0 |
+                             ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_RDMA_READ.0 |
+                             ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND.0 |
+                             ffi::ibv_qp_create_send_ops_flags::IBV_QP_EX_WITH_SEND_WITH_IMM.0) as u32;
+        let mut attr = ffi::ibv_qp_init_attr_ex {
+            qp_context: self.pd.ctx.ctx as *mut _,
+            send_cq: self.send.cq as *const _ as *mut _,
+            recv_cq: self.recv.cq as *const _ as *mut _,
+            cap: ffi::ibv_qp_cap {
+                max_send_wr: self.max_send_wr,
+                max_recv_wr: self.max_recv_wr,
+                max_send_sge: self.max_send_sge,
+                max_recv_sge: self.max_recv_sge,
+                max_inline_data: self.max_inline_data,
+            },
+            qp_type: self.qp_type,
+            sq_sig_all: 1,
+            // attr ex specific
+            comp_mask: (ffi::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_PD | ffi::ibv_qp_init_attr_mask::IBV_QP_INIT_ATTR_SEND_OPS_FLAGS).0,
+            pd: self.pd.pd,
+            send_ops_flags: send_ops_flags as u64,
+            ..Default::default()
+        };
+
+        let mut efa_attr = ffi::efadv_qp_init_attr {
+            driver_qp_type: ffi::EFADV_QP_DRIVER_TYPE_SRD as u32,
+            sl: 0 as u8,
+            ..Default::default()
+        };
+
+        let qp = unsafe { ffi::efadv_create_qp_ex(self.pd.ctx.ctx, &mut attr, &mut efa_attr as *mut _, std::mem::size_of::<ffi::efadv_qp_init_attr>() as u32) };
+        if qp.is_null() {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(PreparedQueuePair {
+                lid: self.port_attr.lid,
+                qp: QueuePair {
+                    pd: self.pd.clone(),
+                    qp,
+                    ah: ptr::null_mut(),
                 },
                 gid_index: self.gid_index,
                 traffic_class: self.traffic_class,
@@ -1232,7 +1316,7 @@ pub struct PreparedQueuePair {
 /// endianness.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[repr(transparent)]
+#[repr(align(8))] // Ensure 8-byte alignment
 pub struct Gid {
     raw: [u8; 16],
 }
@@ -1331,7 +1415,7 @@ impl From<ffi::ibv_gid_entry> for GidEntry {
 /// An identifier for the network endpoint of a `QueuePair`.
 ///
 /// Internally, this contains the `QueuePair`'s `qp_num`, as well as the context's `lid` and `gid`.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct QueuePairEndpoint {
     /// the `QueuePair`'s `qp_num`
@@ -1498,6 +1582,102 @@ impl PreparedQueuePair {
 
         Ok(self.qp)
     }
+
+    /// Build a new QueuePair for EFA.
+    /// Modifies the QP state to INIT, RTR, and RTS. It also creates an AH for the remote endpoint,
+    /// allowing for RDMA operations to that endpoint.
+    ///
+    /// Note that since EFA is a connectionless protocol, the handshake is simply modifying the QP 
+    /// state from INIT -> RTS. A successful handshake does NOT gurantee that the remote endpoint
+    /// has successfully completed its own handshake. As such, the sender usually needs to retry
+    /// the first write request, OR have some other mechanism with which to gurantee that the 
+    /// receiver has completed its handshake first.
+    ///
+    /// # Errors
+    ///
+    ///  - `EINVAL`: Invalid value provided in `attr` or in `attr_mask`.
+    ///  - `ENOMEM`: Not enough resources to complete this operation.
+    pub fn handshake_efa(mut self, remote: QueuePairEndpoint) -> io::Result<QueuePair> {
+        let qp = self.qp.qp;
+        let mut attr = std::mem::MaybeUninit::<ffi::ibv_qp_attr>::uninit();
+        unsafe {
+            std::ptr::write_bytes(attr.as_mut_ptr(), 0, 1);
+            let attr_ptr = attr.as_mut_ptr();
+            (*attr_ptr).qp_state = ffi::ibv_qp_state::IBV_QPS_INIT;
+            (*attr_ptr).qkey = UD_QKEY;
+            (*attr_ptr).pkey_index = 0;
+            (*attr_ptr).port_num = PORT_NUM;
+        }
+
+        let mask = (ffi::ibv_qp_attr_mask::IBV_QP_STATE.0 |
+                   ffi::ibv_qp_attr_mask::IBV_QP_PKEY_INDEX.0 |
+                   ffi::ibv_qp_attr_mask::IBV_QP_PORT.0 |
+                   ffi::ibv_qp_attr_mask::IBV_QP_QKEY.0) as i32;
+
+        let errno = unsafe { ffi::ibv_modify_qp(qp, attr.as_mut_ptr(), mask) };
+        if errno != 0 {
+            return Err(io::Error::from_raw_os_error(errno));
+        }
+
+        // set RTR
+        unsafe {
+            std::ptr::write_bytes(attr.as_mut_ptr(), 0, 1);
+            (*attr.as_mut_ptr()).qp_state = ffi::ibv_qp_state::IBV_QPS_RTR;
+        }
+
+        let mask = ffi::ibv_qp_attr_mask::IBV_QP_STATE.0 as i32;
+
+        let errno = unsafe { ffi::ibv_modify_qp(qp, attr.as_mut_ptr(), mask) };
+        if errno != 0 {
+            return Err(io::Error::from_raw_os_error(errno));
+        }
+
+        // set RTS
+        unsafe {
+            std::ptr::write_bytes(attr.as_mut_ptr(), 0, 1);
+            let attr_ptr = attr.as_mut_ptr();
+            (*attr_ptr).qp_state = ffi::ibv_qp_state::IBV_QPS_RTS;
+            (*attr_ptr).rnr_retry = self.rnr_retry.unwrap_or(3);
+        }
+
+        let mask = (ffi::ibv_qp_attr_mask::IBV_QP_STATE.0 |
+                   ffi::ibv_qp_attr_mask::IBV_QP_SQ_PSN.0 |
+                   ffi::ibv_qp_attr_mask::IBV_QP_RNR_RETRY.0) as i32;
+
+        let errno = unsafe { ffi::ibv_modify_qp(qp, attr.as_mut_ptr(), mask) };
+        if errno != 0 {
+            return Err(io::Error::from_raw_os_error(errno));
+        }
+
+        // Ensure we have a valid AH for EFA operations
+        let ah = if self.qp.ah.is_null() {
+            let mut ah_attr = ffi::ibv_ah_attr {
+                dlid: remote.lid,
+                sl: 0,
+                src_path_bits: 0,
+                port_num: PORT_NUM,
+                is_global: 1,
+                static_rate: 0,
+                grh: ffi::ibv_global_route {
+                    dgid: remote.gid.unwrap().into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            let test_ah = unsafe { ffi::ibv_create_ah(self.qp.pd.pd, &mut ah_attr as *mut _) };
+            if test_ah.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            test_ah
+        } else {
+            self.qp.ah
+        };
+
+        self.qp.ah = ah;
+
+        Ok(self.qp)
+    }
 }
 
 struct MemoryRegionInner {
@@ -1513,7 +1693,7 @@ impl Drop for MemoryRegionInner {
         let errno = unsafe { ffi::ibv_dereg_mr(self.mr) };
         if errno != 0 {
             let e = io::Error::from_raw_os_error(errno);
-            panic!("{e}");
+            panic!("Failed to deregister MR: {e}");
         }
     }
 }
@@ -1649,7 +1829,7 @@ impl Drop for ProtectionDomainInner {
         let errno = unsafe { ffi::ibv_dealloc_pd(self.pd) };
         if errno != 0 {
             let e = io::Error::from_raw_os_error(errno);
-            panic!("{e}");
+            panic!("Failed to deallocate PD: {e}");
         }
     }
 }
@@ -1856,6 +2036,7 @@ impl ProtectionDomain {
 pub struct QueuePair {
     pd: Arc<ProtectionDomainInner>,
     qp: *mut ffi::ibv_qp,
+    ah: *mut ffi::ibv_ah,
 }
 
 unsafe impl Send for QueuePair {}
@@ -2022,6 +2203,50 @@ impl QueuePair {
     }
 
     #[inline]
+    /// Remote RDMA write with EFA.
+    /// immediate data can be used to signal the completion of the write operation
+    /// the other side uses post_recv on a dummy buffer and get the imm data from the work completion
+    pub fn post_write_efa(
+        &mut self,
+        local: &[LocalMemorySlice],
+        remote_mr: RemoteMemorySlice,
+        remote_endpoint: QueuePairEndpoint,
+        wr_id: u64,
+        imm_data: Option<u32>,
+    ) -> io::Result<()> {
+        let qp_ex = unsafe { ffi::ibv_qp_to_qp_ex(self.qp) };
+
+        unsafe {
+            (*qp_ex).wr_start.unwrap()(qp_ex);
+            (*qp_ex).wr_id = wr_id;
+            (*qp_ex).comp_mask = 0;
+            (*qp_ex).wr_flags = ffi::ibv_send_flags::IBV_SEND_SIGNALED.0;
+            if imm_data.is_some() {
+                (*qp_ex).wr_rdma_write_imm.unwrap()(qp_ex, remote_mr.rkey, remote_mr.addr, imm_data.unwrap().to_be());
+            } else {
+                (*qp_ex).wr_rdma_write.unwrap()(qp_ex, remote_mr.rkey, remote_mr.addr);
+            };
+            (*qp_ex).wr_set_sge_list.unwrap()(qp_ex, local.len(), local.as_ptr() as *mut ffi::ibv_sge);
+            // TODO(Eric): Consider creating and caching AH for each remote_endpoint...
+            // This way a single QP can be shared for multiple remote endpoints.
+            (*qp_ex).wr_set_ud_addr.unwrap()(qp_ex, self.ah, remote_endpoint.num, UD_QKEY);
+        };
+
+        let errno = unsafe {(*qp_ex).wr_complete.unwrap()(qp_ex)};
+        if errno != 0 {
+            Err(io::Error::from_raw_os_error(errno))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    /// Get raw QP pointer (for testing/debugging purposes only).
+    pub fn raw_qp_ptr(&self) -> *mut ffi::ibv_qp {
+        self.qp
+    }
+
+    #[inline]
     /// Remote RDMA read.
     /// RDMA read does not support immediate data.
     pub fn post_read(
@@ -2085,11 +2310,20 @@ impl QueuePair {
 
 impl Drop for QueuePair {
     fn drop(&mut self) {
+        // Destroy the address handle if it exists
+        if !self.ah.is_null() {
+            let errno = unsafe { ffi::ibv_destroy_ah(self.ah) };
+            if errno != 0 {
+                let e = io::Error::from_raw_os_error(errno);
+                panic!("Failed to destroy AH: {e}");
+            }
+        }
+
         // TODO: ibv_destroy_qp() fails if the QP is attached to a multicast group.
         let errno = unsafe { ffi::ibv_destroy_qp(self.qp) };
         if errno != 0 {
             let e = io::Error::from_raw_os_error(errno);
-            panic!("{e}");
+            panic!("Failed to destroy QP: {e}");
         }
     }
 }


### PR DESCRIPTION
# Adding EFA Support to `rust-ibverbs`

**Tested on:** AWS instances with EFA NICs

## Key Parity Functions Added

- **`build_efa()`**  
  Mirrors `build()`, but uses the extended `libibverbs` API to create an **SRD QP**.

- **`handshake_efa()`**  
  Unlike RC QP handshakes, EFA is connectionless. This function:  
  - Transitions QP state: `INIT → RTR → RTS`  
  - Creates and binds the required **Address Handle (AH)** to authorize sends to the remote peer.

- **`post_write_efa()`**  
  Uses extended API to build a work request.  
  `ud_data.addr` must point to the target **AH**.

These functions are all hidden behind a prop passed down from the QueuePairBuilder (QueuePairBuilder.enable_efa(true)). By enabling this, the proper efa version of the method will be called.

This keeps the user's interfaces nearly the exact same.