### PR TITLE
Allow slicing a whole memory region

### DIFF
--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1571,6 +1571,21 @@ impl<T> MemoryRegion<T> {
             lkey: unsafe { *self.inner.mr }.lkey,
         }
     }
+
+    /// Make a subslice of this memory region.
+    pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
+        let (addr, length) = calc_addr_len(
+            bounds,
+            unsafe { *self.inner.mr }.addr as u64,
+            unsafe { *self.inner.mr }.length,
+        );
+        let sge = ffi::ibv_sge {
+            addr,
+            length: length.try_into().unwrap(),
+            lkey: unsafe { *self.inner.mr }.lkey,
+        };
+        LocalMemorySlice { _sge: sge }
+    }
 }
 
 /// Local memory slice.

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1560,7 +1560,7 @@ impl<T> MemoryRegion<T> {
     /// Unlike `LocalMemorySlice`, this supports 64-bit memory region lengths.
     pub fn as_slice(&self) -> MemoryRegionSlice {
         MemoryRegionSlice {
-            addr,
+            addr: unsafe { *self.inner.mr }.addr as u64,
             length: unsafe { *self.inner.mr }.length as u64,
             lkey: unsafe { *self.inner.mr }.lkey,
         }
@@ -1638,7 +1638,7 @@ pub struct MemoryRegionSlice {
 impl MemoryRegionSlice {
     /// Make a slice of this memory region.
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
-        let (addr, len) = calc_addr_len(bounds, self.addr, self.len());
+        let (addr, len) = calc_addr_len(bounds, self.addr, self.length as usize);
         LocalMemorySlice {
             _sge: ffi::ibv_sge {
                 addr,

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1556,6 +1556,21 @@ impl<T> MemoryRegion<T> {
         self.data
     }
 
+    /// Make a lifetime-independent slice representation of this memory region.
+    /// Unlike `LocalMemorySlice`, this supports 64-bit memory region lengths.
+    pub fn as_slice(&self) -> MemoryRegionSlice {
+        let (addr, length) = calc_addr_len(
+            bounds,
+            unsafe { *self.inner.mr }.addr as u64,
+            unsafe { *self.inner.mr }.length,
+        );
+        MemoryRegionSlice {
+            addr,
+            length: length as u64,
+            lkey: unsafe { *self.inner.mr }.lkey,
+        }
+    }
+
     /// Make a subslice of this memory region.
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
         let (addr, length) = calc_addr_len(
@@ -1604,6 +1619,49 @@ impl LocalMemorySlice {
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> Self {
         let (addr, len) = calc_addr_len(bounds, self.addr(), self.len());
         Self {
+            _sge: ffi::ibv_sge {
+                addr,
+                length: len.try_into().unwrap(),
+                lkey: self.lkey(),
+            },
+        }
+    }
+}
+
+/// Lifetime-independent slice representation of a memory region.
+/// Unlike `LocalMemorySlice`, this supports 64-bit memory region lengths.
+#[derive(Debug, Default, Copy, Clone)]
+pub struct MemoryRegionSlice {
+    addr: u64,
+    length: u64,
+    lkey: u32,
+}
+
+impl MemoryRegionSlice {
+    /// Get the address of the memory region.
+    pub fn addr(&self) -> u64 {
+        self.addr
+    }
+
+    /// Get the length of the memory region.
+    pub fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    /// Get is_empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get the local key of the memory region.
+    pub fn lkey(&self) -> u32 {
+        self.lkey
+    }
+
+    /// Make a slice of this memory region.
+    pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
+        let (addr, len) = calc_addr_len(bounds, self.addr(), self.len());
+        LocalMemorySlice {
             _sge: ffi::ibv_sge {
                 addr,
                 length: len.try_into().unwrap(),

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1570,21 +1570,6 @@ impl<T> MemoryRegion<T> {
             lkey: unsafe { *self.inner.mr }.lkey,
         }
     }
-
-    /// Make a subslice of this memory region.
-    pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
-        let (addr, length) = calc_addr_len(
-            bounds,
-            unsafe { *self.inner.mr }.addr as u64,
-            unsafe { *self.inner.mr }.length,
-        );
-        let sge = ffi::ibv_sge {
-            addr,
-            length: length.try_into().unwrap(),
-            lkey: unsafe { *self.inner.mr }.lkey,
-        };
-        LocalMemorySlice { _sge: sge }
-    }
 }
 
 /// Local memory slice.
@@ -1660,6 +1645,7 @@ impl MemoryRegionSlice {
 
     /// Make a slice of this memory region.
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
+        let bounds = (..unsafe { *self.inner.mr }.length);
         let (addr, len) = calc_addr_len(bounds, self.addr(), self.len());
         LocalMemorySlice {
             _sge: ffi::ibv_sge {

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1559,15 +1559,9 @@ impl<T> MemoryRegion<T> {
     /// Make a lifetime-independent slice representation of this memory region.
     /// Unlike `LocalMemorySlice`, this supports 64-bit memory region lengths.
     pub fn as_slice(&self) -> MemoryRegionSlice {
-        let bounds = (..unsafe { *self.inner.mr }.length);
-        let (addr, length) = calc_addr_len(
-            bounds,
-            unsafe { *self.inner.mr }.addr as u64,
-            unsafe { *self.inner.mr }.length,
-        );
         MemoryRegionSlice {
             addr,
-            length: length as u64,
+            length: unsafe { *self.inner.mr }.length as u64,
             lkey: unsafe { *self.inner.mr }.lkey,
         }
     }
@@ -1633,40 +1627,23 @@ impl LocalMemorySlice {
 /// Unlike `LocalMemorySlice`, this supports 64-bit memory region lengths.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MemoryRegionSlice {
-    addr: u64,
-    length: u64,
-    lkey: u32,
+    /// Memory region base address
+    pub addr: u64,
+    /// Memory region length
+    pub length: u64,
+    /// Memory region lkey
+    pub lkey: u32,
 }
 
 impl MemoryRegionSlice {
-    /// Get the address of the memory region.
-    pub fn addr(&self) -> u64 {
-        self.addr
-    }
-
-    /// Get the length of the memory region.
-    pub fn len(&self) -> usize {
-        self.length as usize
-    }
-
-    /// Get is_empty
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Get the local key of the memory region.
-    pub fn lkey(&self) -> u32 {
-        self.lkey
-    }
-
     /// Make a slice of this memory region.
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
-        let (addr, len) = calc_addr_len(bounds, self.addr(), self.len());
+        let (addr, len) = calc_addr_len(bounds, self.addr, self.len());
         LocalMemorySlice {
             _sge: ffi::ibv_sge {
                 addr,
                 length: len.try_into().unwrap(),
-                lkey: self.lkey(),
+                lkey: self.lkey,
             },
         }
     }

--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -1559,6 +1559,7 @@ impl<T> MemoryRegion<T> {
     /// Make a lifetime-independent slice representation of this memory region.
     /// Unlike `LocalMemorySlice`, this supports 64-bit memory region lengths.
     pub fn as_slice(&self) -> MemoryRegionSlice {
+        let bounds = (..unsafe { *self.inner.mr }.length);
         let (addr, length) = calc_addr_len(
             bounds,
             unsafe { *self.inner.mr }.addr as u64,
@@ -1645,7 +1646,6 @@ impl MemoryRegionSlice {
 
     /// Make a slice of this memory region.
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> LocalMemorySlice {
-        let bounds = (..unsafe { *self.inner.mr }.length);
         let (addr, len) = calc_addr_len(bounds, self.addr(), self.len());
         LocalMemorySlice {
             _sge: ffi::ibv_sge {


### PR DESCRIPTION
This allows 64-bit slices unlike LocalMemoryRegion